### PR TITLE
Long-press multi-select with bulk delete + intermediary 3-dots picker

### DIFF
--- a/lib/l10n/app_strings.dart
+++ b/lib/l10n/app_strings.dart
@@ -809,6 +809,15 @@ class AppStrings {
   String get selectIntermediary    => _it ? 'Seleziona intermediario'   : 'Select Intermediary';
   String get close                 => _it ? 'Chiudi'                    : 'Close';
 
+  // ── Multi-select ─────────────────────────────────────────
+  String nSelected(int n)          => _it ? '$n selezionati'            : '$n selected';
+  String get selectAll             => _it ? 'Seleziona tutto'           : 'Select all';
+  String get deselectAll           => _it ? 'Deseleziona tutto'         : 'Deselect all';
+  String get bulkDeleteTitle       => _it ? 'Eliminare gli elementi?'   : 'Delete items?';
+  String bulkDeleteBody(int n)     => _it
+      ? 'Verranno eliminati $n elementi. Operazione irreversibile.'
+      : '$n items will be permanently deleted. This cannot be undone.';
+
   // ── DB Picker ────────────────────────────────────────────
   String get dbPickerTitle        => _it ? 'Apri un database'        : 'Open a Database';
   String get dbPickerOpenFile     => _it ? 'Apri file...'            : 'Open File...';

--- a/lib/services/account_service.dart
+++ b/lib/services/account_service.dart
@@ -84,6 +84,14 @@ class AccountService {
     return (_db.delete(_db.accounts)..where((a) => a.id.equals(id))).go();
   }
 
+  Future<int> deleteMany(List<int> ids) async {
+    if (ids.isEmpty) return 0;
+    _log.warning('deleteMany: ${ids.length} accounts (cascade: transactions, import configs)');
+    await (_db.delete(_db.transactions)..where((t) => t.accountId.isIn(ids))).go();
+    await (_db.delete(_db.importConfigs)..where((c) => c.accountId.isIn(ids))).go();
+    return (_db.delete(_db.accounts)..where((a) => a.id.isIn(ids))).go();
+  }
+
   /// Reorder accounts by updating sortOrder for each account.
   Future<void> reorder(List<int> orderedIds) async {
     _log.info('reorder: ${orderedIds.length} accounts');

--- a/lib/services/asset_event_service.dart
+++ b/lib/services/asset_event_service.dart
@@ -79,6 +79,12 @@ class AssetEventService {
     return (_db.delete(_db.assetEvents)..where((e) => e.id.equals(id))).go();
   }
 
+  Future<int> deleteMany(List<int> ids) {
+    if (ids.isEmpty) return Future.value(0);
+    _log.warning('deleteMany: ${ids.length} events');
+    return (_db.delete(_db.assetEvents)..where((e) => e.id.isIn(ids))).go();
+  }
+
   Future<int> deleteByAsset(int assetId) {
     _log.warning('deleteByAsset: assetId=$assetId');
     return (_db.delete(_db.assetEvents)..where((e) => e.assetId.equals(assetId))).go();

--- a/lib/services/asset_service.dart
+++ b/lib/services/asset_service.dart
@@ -85,6 +85,15 @@ class AssetService {
     return (_db.delete(_db.assets)..where((a) => a.id.equals(id))).go();
   }
 
+  Future<int> deleteMany(List<int> ids) async {
+    if (ids.isEmpty) return 0;
+    _log.warning('deleteMany: ${ids.length} assets (cascade: events, snapshots, prices)');
+    await (_db.delete(_db.assetEvents)..where((e) => e.assetId.isIn(ids))).go();
+    await (_db.delete(_db.assetSnapshots)..where((s) => s.assetId.isIn(ids))).go();
+    await (_db.delete(_db.marketPrices)..where((p) => p.assetId.isIn(ids))).go();
+    return (_db.delete(_db.assets)..where((a) => a.id.isIn(ids))).go();
+  }
+
   Future<void> reorder(List<int> orderedIds) async {
     _log.info('reorder: ${orderedIds.length} assets');
     await _db.batch((batch) {

--- a/lib/services/capex_service.dart
+++ b/lib/services/capex_service.dart
@@ -109,6 +109,20 @@ class CapexService {
     return (_db.delete(_db.depreciationSchedules)..where((s) => s.id.equals(id))).go();
   }
 
+  /// Delete multiple schedules in one transaction. Delegates to [delete] per id
+  /// so the buffer/entry cascade logic lives in exactly one place.
+  Future<int> deleteMany(List<int> ids) async {
+    if (ids.isEmpty) return 0;
+    _log.warning('deleteMany: ${ids.length} schedules');
+    return _db.transaction(() async {
+      var total = 0;
+      for (final id in ids) {
+        total += await delete(id);
+      }
+      return total;
+    });
+  }
+
   // ── Entry generation ──
   // Entries reflect (totalAmount - reimbursements) spread across steps.
 

--- a/lib/services/income_adjustment_service.dart
+++ b/lib/services/income_adjustment_service.dart
@@ -73,6 +73,17 @@ class IncomeAdjustmentService {
         .go();
   }
 
+  Future<int> deleteMany(List<int> ids) async {
+    if (ids.isEmpty) return 0;
+    _log.warning('deleteMany: ${ids.length} income adjustments (cascade: expenses)');
+    await (_db.delete(_db.incomeAdjustmentExpenses)
+          ..where((e) => e.adjustmentId.isIn(ids)))
+        .go();
+    return (_db.delete(_db.incomeAdjustments)
+          ..where((a) => a.id.isIn(ids)))
+        .go();
+  }
+
   // ── Expenses CRUD ──
 
   Stream<List<IncomeAdjustmentExpense>> watchExpenses(int adjustmentId) {

--- a/lib/services/income_service.dart
+++ b/lib/services/income_service.dart
@@ -68,6 +68,12 @@ class IncomeService {
         .go();
   }
 
+  Future<int> deleteMany(List<int> ids) {
+    if (ids.isEmpty) return Future.value(0);
+    _log.warning('deleteMany: ${ids.length} incomes');
+    return (_db.delete(_db.incomes)..where((i) => i.id.isIn(ids))).go();
+  }
+
   Future<void> bulkCreate(List<IncomesCompanion> entries) async {
     _log.info('bulkCreate: ${entries.length} entries');
     await _db.batch((batch) {

--- a/lib/services/transaction_service.dart
+++ b/lib/services/transaction_service.dart
@@ -71,6 +71,12 @@ class TransactionService {
     return (_db.delete(_db.transactions)..where((t) => t.id.equals(id))).go();
   }
 
+  Future<int> deleteMany(List<int> ids) {
+    if (ids.isEmpty) return Future.value(0);
+    _log.warning('deleteMany: ${ids.length} transactions');
+    return (_db.delete(_db.transactions)..where((t) => t.id.isIn(ids))).go();
+  }
+
   /// Batch-update balanceAfter for multiple transactions in a single DB transaction.
   Future<void> batchUpdateBalances(Map<int, double?> updates) async {
     await _db.batch((batch) {

--- a/lib/ui/screens/account_detail_screen.dart
+++ b/lib/ui/screens/account_detail_screen.dart
@@ -11,6 +11,9 @@ import '../../utils/formatters.dart' as fmt;
 import '../../utils/logger.dart';
 import 'import/import_screen.dart';
 import 'transaction_edit_screen.dart';
+import '../widgets/selection/selectable_item.dart';
+import '../widgets/selection/selection_action_bar.dart';
+import '../widgets/selection/selection_controller.dart';
 
 final _log = getLogger('AccountDetailScreen');
 
@@ -26,10 +29,12 @@ class AccountDetailScreen extends ConsumerStatefulWidget {
 class _AccountDetailScreenState extends ConsumerState<AccountDetailScreen> {
   final _searchCtrl = TextEditingController();
   String _searchQuery = '';
+  final _selection = SelectionController<int>();
 
   @override
   void dispose() {
     _searchCtrl.dispose();
+    _selection.dispose();
     super.dispose();
   }
 
@@ -41,7 +46,24 @@ class _AccountDetailScreenState extends ConsumerState<AccountDetailScreen> {
     final dateFmt = fmt.shortDateFormat(locale);
     final amtFmt = fmt.currencyFormat(locale, widget.account.currency);
 
-    return Scaffold(
+    return ListenableBuilder(
+      listenable: _selection,
+      builder: (lbCtx, _) {
+        // Filtered ids snapshot for the action bar's "select all".
+        List<int> visibleIds = const [];
+        txStream.whenData((transactions) {
+          final filtered = _searchQuery.isEmpty
+              ? transactions
+              : transactions.where((t) {
+                  return t.description.toLowerCase().contains(_searchQuery) ||
+                      (t.descriptionFull?.toLowerCase().contains(_searchQuery) ?? false) ||
+                      t.amount.toString().contains(_searchQuery);
+                }).toList();
+          visibleIds = filtered.map((t) => t.id).toList();
+        });
+        _selection.setOrderedIds(visibleIds);
+
+        return Scaffold(
       appBar: AppBar(
         title: Text(widget.account.name),
         actions: [
@@ -136,7 +158,10 @@ class _AccountDetailScreenState extends ConsumerState<AccountDetailScreen> {
                   itemBuilder: (ctx, i) {
                     final tx = filtered[i];
                     final isPositive = tx.amount >= 0;
-                    return ListTile(
+                    return SelectableItem<int>(
+                      controller: _selection,
+                      id: tx.id,
+                      child: ListTile(
                       dense: true,
                       leading: CircleAvatar(
                         radius: 16,
@@ -193,6 +218,7 @@ class _AccountDetailScreenState extends ConsumerState<AccountDetailScreen> {
                         ],
                       ),
                       onTap: () => _openTransaction(tx),
+                      ),
                     );
                   },
                 );
@@ -242,6 +268,15 @@ class _AccountDetailScreenState extends ConsumerState<AccountDetailScreen> {
           ),
         ],
       ),
+          bottomNavigationBar: _selection.active
+              ? SelectionActionBar<int>(
+                  controller: _selection,
+                  visibleIds: visibleIds,
+                  onDelete: (ids) => ref.read(transactionServiceProvider).deleteMany(ids.toList()),
+                )
+              : null,
+        );
+      },
     );
   }
 

--- a/lib/ui/screens/accounts_screen.dart
+++ b/lib/ui/screens/accounts_screen.dart
@@ -12,6 +12,9 @@ import '../../utils/formatters.dart' as fmt;
 import 'account_detail_screen.dart';
 import 'dashboard/dashboard_screen.dart' show currencySymbol;
 import '../widgets/privacy_text.dart';
+import '../widgets/selection/selectable_item.dart';
+import '../widgets/selection/selection_action_bar.dart';
+import '../widgets/selection/selection_controller.dart';
 
 class AccountsScreen extends ConsumerStatefulWidget {
   const AccountsScreen({super.key});
@@ -21,6 +24,14 @@ class AccountsScreen extends ConsumerStatefulWidget {
 }
 
 class _AccountsScreenState extends ConsumerState<AccountsScreen> {
+  final _selection = SelectionController<int>();
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final s = ref.watch(appStringsProvider);
@@ -31,7 +42,24 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     final locale = ref.watch(appLocaleProvider).value ?? Platform.localeName;
     final convertedStats = ref.watch(convertedAccountStatsProvider).value ?? {};
 
-    return Scaffold(
+    return ListenableBuilder(
+      listenable: _selection,
+      builder: (lbCtx, _) {
+        // Build the id list in rendered order: grouped by intermediary, then
+        // unassigned last. This matches what _buildGroup actually displays
+        // and is what range-select on long-press needs.
+        final accounts = accountsAsync.value ?? const <Account>[];
+        final intermediaries = intermediariesAsync.value ?? const <Intermediary>[];
+        final grouping = <int?, List<int>>{};
+        for (final a in accounts) {
+          (grouping[a.intermediaryId] ??= []).add(a.id);
+        }
+        final allAccountIds = <int>[
+          for (final i in intermediaries) ...?grouping[i.id],
+          ...?grouping[null],
+        ];
+        _selection.setOrderedIds(allAccountIds);
+        return Scaffold(
       body: accountsAsync.when(
         data: (accounts) {
           if (accounts.isEmpty && (intermediariesAsync.value ?? []).isEmpty) {
@@ -86,22 +114,33 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text(s.error(e))),
       ),
-      floatingActionButton: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          FloatingActionButton.small(
-            heroTag: 'add_intermediary',
-            onPressed: () => _showManageIntermediariesDialog(context),
-            child: const Icon(Icons.business),
-          ),
-          const SizedBox(height: 8),
-          FloatingActionButton(
-            heroTag: 'add_account',
-            onPressed: () => _showCreateDialog(context),
-            child: const Icon(Icons.add),
-          ),
-        ],
-      ),
+      bottomNavigationBar: _selection.active
+          ? SelectionActionBar<int>(
+              controller: _selection,
+              visibleIds: allAccountIds,
+              onDelete: (ids) => ref.read(accountServiceProvider).deleteMany(ids.toList()),
+            )
+          : null,
+      floatingActionButton: _selection.active
+          ? null
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FloatingActionButton.small(
+                  heroTag: 'add_intermediary',
+                  onPressed: () => _showManageIntermediariesDialog(context),
+                  child: const Icon(Icons.business),
+                ),
+                const SizedBox(height: 8),
+                FloatingActionButton(
+                  heroTag: 'add_account',
+                  onPressed: () => _showCreateDialog(context),
+                  child: const Icon(Icons.add),
+                ),
+              ],
+            ),
+    );
+      },
     );
   }
 
@@ -145,23 +184,27 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
           ),
         ),
         ...accounts.map((account) {
-          return _AccountTile(
+          return SelectableItem<int>(
             key: ValueKey(account.id),
-            account: account,
-            stats: stats[account.id],
-            convertedBalance: convertedStats[account.id],
-            baseCurrency: baseCurrency,
-            locale: locale,
-            intermediaries: intermediaries,
-            onMove: (newId) {
-              if (newId != account.intermediaryId) {
-                ref.read(intermediaryServiceProvider).moveAccount(account.id, newId);
-              }
-            },
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => AccountDetailScreen(account: account),
+            controller: _selection,
+            id: account.id,
+            child: _AccountTile(
+              account: account,
+              stats: stats[account.id],
+              convertedBalance: convertedStats[account.id],
+              baseCurrency: baseCurrency,
+              locale: locale,
+              intermediaries: intermediaries,
+              onMove: (newId) {
+                if (newId != account.intermediaryId) {
+                  ref.read(intermediaryServiceProvider).moveAccount(account.id, newId);
+                }
+              },
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => AccountDetailScreen(account: account),
+                ),
               ),
             ),
           );
@@ -386,7 +429,6 @@ class _AccountTile extends ConsumerWidget {
   final void Function(int? newIntermediaryId) onMove;
 
   const _AccountTile({
-    super.key,
     required this.account,
     required this.stats,
     this.convertedBalance,

--- a/lib/ui/screens/accounts_screen.dart
+++ b/lib/ui/screens/accounts_screen.dart
@@ -21,8 +21,6 @@ class AccountsScreen extends ConsumerStatefulWidget {
 }
 
 class _AccountsScreenState extends ConsumerState<AccountsScreen> {
-  bool _isDragging = false;
-
   @override
   Widget build(BuildContext context) {
     final s = ref.watch(appStringsProvider);
@@ -74,12 +72,13 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             padding: const EdgeInsets.only(bottom: 80),
             children: [
               for (final groupId in groupOrder)
-                if (_isDragging || (grouped[groupId]?.isNotEmpty ?? false))
+                if (grouped[groupId]?.isNotEmpty ?? false)
                   _buildGroup(
                     context, s, groupId,
                     groupId == null ? null : intermediaries.firstWhere((i) => i.id == groupId),
                     grouped[groupId] ?? [],
                     stats, convertedStats, baseCurrency, locale,
+                    intermediaries,
                   ),
             ],
           );
@@ -116,106 +115,59 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     Map<int, double?> convertedStats,
     String baseCurrency,
     String locale,
+    List<Intermediary> intermediaries,
   ) {
     final title = intermediary?.name ?? s.unassigned;
 
-    return DragTarget<_DraggedAccount>(
-      onWillAcceptWithDetails: (details) => details.data.currentIntermediaryId != groupId,
-      onAcceptWithDetails: (details) {
-        ref.read(intermediaryServiceProvider).moveAccount(details.data.accountId, groupId);
-      },
-      builder: (context, candidateData, rejectedData) {
-        final isHovering = candidateData.isNotEmpty;
-        return Container(
-          color: isHovering ? Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.3) : null,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
             children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: Row(
-                  children: [
-                    Icon(
-                      intermediary != null ? Icons.business : Icons.folder_open,
-                      size: 18,
-                      color: Colors.grey,
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        '$title (${accounts.length})',
-                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ),
-                    if (intermediary != null)
-                      PopupMenuButton<String>(
-                        iconSize: 22,
-                        itemBuilder: (_) => [
-                          PopupMenuItem(value: 'edit', child: Text(s.editIntermediary)),
-                          PopupMenuItem(value: 'delete', child: Text(s.deleteIntermediary)),
-                        ],
-                        onSelected: (v) {
-                          if (v == 'edit') _showIntermediaryDialog(context, intermediary: intermediary);
-                          if (v == 'delete') _confirmDeleteIntermediary(context, intermediary);
-                        },
-                      ),
-                  ],
+              Icon(
+                intermediary != null ? Icons.business : Icons.folder_open,
+                size: 18,
+                color: Colors.grey,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '$title (${accounts.length})',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ),
-              ...accounts.map((account) {
-                  return LongPressDraggable<_DraggedAccount>(
-                    delay: const Duration(milliseconds: 150),
-                    data: _DraggedAccount(account.id, account.intermediaryId),
-                    onDragStarted: () => setState(() => _isDragging = true),
-                    onDragEnd: (_) => setState(() => _isDragging = false),
-                    onDraggableCanceled: (_, _) => setState(() => _isDragging = false),
-                    feedback: Material(
-                      elevation: 4,
-                      borderRadius: BorderRadius.circular(8),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.surface,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Text(account.name, style: const TextStyle(fontWeight: FontWeight.w600)),
-                      ),
-                    ),
-                    childWhenDragging: Opacity(
-                      opacity: 0.3,
-                      child: _AccountTile(
-                        account: account,
-                        stats: stats[account.id],
-                        convertedBalance: convertedStats[account.id],
-                        baseCurrency: baseCurrency,
-                        locale: locale,
-                        onTap: () {},
-                      ),
-                    ),
-                    child: _AccountTile(
-                      key: ValueKey(account.id),
-                      account: account,
-                      stats: stats[account.id],
-                      convertedBalance: convertedStats[account.id],
-                      baseCurrency: baseCurrency,
-                      locale: locale,
-                      onTap: () => Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => AccountDetailScreen(account: account),
-                        ),
-                      ),
-                    ),
-                  );
-                }),
-              const Divider(height: 1),
             ],
           ),
-        );
-      },
+        ),
+        ...accounts.map((account) {
+          return _AccountTile(
+            key: ValueKey(account.id),
+            account: account,
+            stats: stats[account.id],
+            convertedBalance: convertedStats[account.id],
+            baseCurrency: baseCurrency,
+            locale: locale,
+            intermediaries: intermediaries,
+            onMove: (newId) {
+              if (newId != account.intermediaryId) {
+                ref.read(intermediaryServiceProvider).moveAccount(account.id, newId);
+              }
+            },
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => AccountDetailScreen(account: account),
+              ),
+            ),
+          );
+        }),
+        const Divider(height: 1),
+      ],
     );
   }
 
@@ -423,12 +375,6 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   }
 }
 
-class _DraggedAccount {
-  final int accountId;
-  final int? currentIntermediaryId;
-  const _DraggedAccount(this.accountId, this.currentIntermediaryId);
-}
-
 class _AccountTile extends ConsumerWidget {
   final Account account;
   final AccountStats? stats;
@@ -436,6 +382,8 @@ class _AccountTile extends ConsumerWidget {
   final String baseCurrency;
   final String locale;
   final VoidCallback onTap;
+  final List<Intermediary> intermediaries;
+  final void Function(int? newIntermediaryId) onMove;
 
   const _AccountTile({
     super.key,
@@ -445,6 +393,8 @@ class _AccountTile extends ConsumerWidget {
     required this.baseCurrency,
     required this.locale,
     required this.onTap,
+    required this.intermediaries,
+    required this.onMove,
   });
 
   @override
@@ -540,7 +490,46 @@ class _AccountTile extends ConsumerWidget {
               ],
             ),
             const SizedBox(width: 4),
-            const Icon(Icons.chevron_right, size: 18, color: Colors.grey),
+            PopupMenuButton<int?>(
+              icon: const Icon(Icons.more_vert, size: 20, color: Colors.grey),
+              tooltip: s.selectIntermediary,
+              itemBuilder: (_) => <PopupMenuEntry<int?>>[
+                PopupMenuItem<int?>(
+                  enabled: false,
+                  child: Text(
+                    s.selectIntermediary,
+                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                ),
+                const PopupMenuDivider(),
+                for (final i in intermediaries)
+                  PopupMenuItem<int?>(
+                    value: i.id,
+                    child: Row(
+                      children: [
+                        const Icon(Icons.business, size: 18),
+                        const SizedBox(width: 8),
+                        Expanded(child: Text(i.name)),
+                        if (account.intermediaryId == i.id)
+                          const Icon(Icons.check, size: 18),
+                      ],
+                    ),
+                  ),
+                PopupMenuItem<int?>(
+                  value: null,
+                  child: Row(
+                    children: [
+                      const Icon(Icons.folder_open, size: 18),
+                      const SizedBox(width: 8),
+                      Expanded(child: Text(s.unassigned)),
+                      if (account.intermediaryId == null)
+                        const Icon(Icons.check, size: 18),
+                    ],
+                  ),
+                ),
+              ],
+              onSelected: onMove,
+            ),
           ],
         ),
       ),

--- a/lib/ui/screens/asset_detail_screen.dart
+++ b/lib/ui/screens/asset_detail_screen.dart
@@ -14,16 +14,34 @@ import '../../utils/formatters.dart' as fmt;
 import '../../utils/logger.dart';
 import 'asset_event_edit_screen.dart';
 import 'dashboard/dashboard_screen.dart' show currencySymbol;
+import '../widgets/selection/selectable_item.dart';
+import '../widgets/selection/selection_action_bar.dart';
+import '../widgets/selection/selection_controller.dart';
 
 final _log = getLogger('AssetDetailScreen');
 
 /// Shows events for a single asset, with summary card + event list + edit.
-class AssetDetailScreen extends ConsumerWidget {
+class AssetDetailScreen extends ConsumerStatefulWidget {
   final Asset asset;
   const AssetDetailScreen({super.key, required this.asset});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<AssetDetailScreen> createState() => _AssetDetailScreenState();
+}
+
+class _AssetDetailScreenState extends ConsumerState<AssetDetailScreen> {
+  final _selection = SelectionController<int>();
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
+
+  Asset get asset => widget.asset;
+
+  @override
+  Widget build(BuildContext context) {
     final s = ref.watch(appStringsProvider);
     final eventsStream = ref.watch(assetEventsProvider(asset.id));
     final locale = ref.watch(appLocaleProvider).value ?? Platform.localeName;
@@ -36,7 +54,12 @@ class AssetDetailScreen extends ConsumerWidget {
         ? ref.watch(convertedEventAmountsProvider(asset.id)).value ?? {}
         : <int, double>{};
 
-    return Scaffold(
+    return ListenableBuilder(
+      listenable: _selection,
+      builder: (lbCtx, _) {
+        final events = eventsStream.value ?? const <AssetEvent>[];
+        _selection.setOrderedIds(events.map((e) => e.id).toList());
+        return Scaffold(
       appBar: AppBar(
         title: Text(asset.name),
         actions: [
@@ -127,7 +150,10 @@ class AssetDetailScreen extends ConsumerWidget {
                   itemBuilder: (ctx, i) {
                     final ev = events[i];
                     final typeColor = _colorForEventType(ev.type);
-                    return ListTile(
+                    return SelectableItem<int>(
+                      controller: _selection,
+                      id: ev.id,
+                      child: ListTile(
                       dense: true,
                       leading: CircleAvatar(
                         radius: 16,
@@ -176,6 +202,7 @@ class AssetDetailScreen extends ConsumerWidget {
                           builder: (_) => AssetEventEditScreen(event: ev, asset: asset),
                         ),
                       ),
+                      ),
                     );
                   },
                 );
@@ -186,13 +213,24 @@ class AssetDetailScreen extends ConsumerWidget {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => AssetEventEditScreen(asset: asset)),
-        ),
-        child: const Icon(Icons.add),
-      ),
+          bottomNavigationBar: _selection.active
+              ? SelectionActionBar<int>(
+                  controller: _selection,
+                  visibleIds: events.map((e) => e.id).toList(),
+                  onDelete: (ids) => ref.read(assetEventServiceProvider).deleteMany(ids.toList()),
+                )
+              : null,
+          floatingActionButton: _selection.active
+              ? null
+              : FloatingActionButton(
+                  onPressed: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => AssetEventEditScreen(asset: asset)),
+                  ),
+                  child: const Icon(Icons.add),
+                ),
+        );
+      },
     );
   }
 

--- a/lib/ui/screens/assets_screen.dart
+++ b/lib/ui/screens/assets_screen.dart
@@ -25,15 +25,7 @@ class AssetsScreen extends ConsumerStatefulWidget {
   ConsumerState<AssetsScreen> createState() => _AssetsScreenState();
 }
 
-class _DraggedAsset {
-  final int assetId;
-  final int? currentIntermediaryId;
-  const _DraggedAsset(this.assetId, this.currentIntermediaryId);
-}
-
 class _AssetsScreenState extends ConsumerState<AssetsScreen> {
-  bool _isDragging = false;
-
   @override
   Widget build(BuildContext context) {
     final s = ref.watch(appStringsProvider);
@@ -87,12 +79,13 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
             padding: const EdgeInsets.only(bottom: 80),
             children: [
               for (final groupId in groupOrder)
-                if (_isDragging || (grouped[groupId]?.isNotEmpty ?? false))
+                if (grouped[groupId]?.isNotEmpty ?? false)
                   _buildGroup(
                     context, s, groupId,
                     groupId == null ? null : intermediaries.firstWhere((i) => i.id == groupId),
                     grouped[groupId] ?? [],
                     stats, convertedStats, marketValues, baseCurrency, locale,
+                    intermediaries,
                   ),
             ],
           );
@@ -133,103 +126,60 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
     Map<int, double> marketValues,
     String baseCurrency,
     String locale,
+    List<Intermediary> intermediaries,
   ) {
     final title = intermediary?.name ?? s.unassigned;
 
-    return DragTarget<_DraggedAsset>(
-      onWillAcceptWithDetails: (details) => details.data.currentIntermediaryId != groupId,
-      onAcceptWithDetails: (details) {
-        ref.read(intermediaryServiceProvider).moveAsset(details.data.assetId, groupId);
-      },
-      builder: (context, candidateData, rejectedData) {
-        final isHovering = candidateData.isNotEmpty;
-        return Container(
-          color: isHovering ? Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.3) : null,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
             children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: Row(
-                  children: [
-                    Icon(
-                      intermediary != null ? Icons.business : Icons.folder_open,
-                      size: 18,
-                      color: Colors.grey,
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        '$title (${assets.length})',
-                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ),
-                    if (intermediary != null)
-                      PopupMenuButton<String>(
-                        iconSize: 22,
-                        itemBuilder: (_) => [
-                          PopupMenuItem(value: 'edit', child: Text(s.editIntermediary)),
-                          PopupMenuItem(value: 'delete', child: Text(s.deleteIntermediary)),
-                        ],
-                        onSelected: (v) {
-                          if (v == 'edit') _showIntermediaryDialog(context, intermediary: intermediary);
-                          if (v == 'delete') _confirmDeleteIntermediary(context, intermediary);
-                        },
-                      ),
-                  ],
+              Icon(
+                intermediary != null ? Icons.business : Icons.folder_open,
+                size: 18,
+                color: Colors.grey,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '$title (${assets.length})',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ),
-              ...assets.map((asset) {
-                  final stat = stats[asset.id];
-                  return LongPressDraggable<_DraggedAsset>(
-                    delay: const Duration(milliseconds: 150),
-                    data: _DraggedAsset(asset.id, asset.intermediaryId),
-                    onDragStarted: () => setState(() => _isDragging = true),
-                    onDragEnd: (_) => setState(() => _isDragging = false),
-                    onDraggableCanceled: (_, _) => setState(() => _isDragging = false),
-                    feedback: Material(
-                      elevation: 4,
-                      borderRadius: BorderRadius.circular(8),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.surface,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Text(asset.ticker ?? asset.name, style: const TextStyle(fontWeight: FontWeight.w600)),
-                      ),
-                    ),
-                    childWhenDragging: Opacity(
-                      opacity: 0.3,
-                      child: _AssetTile(
-                        asset: asset, stats: stat,
-                        convertedInvested: convertedStats[asset.id],
-                        marketValue: marketValues[asset.id],
-                        baseCurrency: baseCurrency, locale: locale, strings: s,
-                        onTap: () {},
-                      ),
-                    ),
-                    child: _AssetTile(
-                      key: ValueKey(asset.id),
-                      asset: asset, stats: stat,
-                      convertedInvested: convertedStats[asset.id],
-                      marketValue: marketValues[asset.id],
-                      baseCurrency: baseCurrency, locale: locale, strings: s,
-                      onTap: () => Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (_) => AssetDetailScreen(asset: asset)),
-                      ),
-                    ),
-                  );
-                }),
-              const Divider(height: 1),
             ],
           ),
-        );
-      },
+        ),
+        ...assets.map((asset) {
+          final stat = stats[asset.id];
+          return _AssetTile(
+            key: ValueKey(asset.id),
+            asset: asset,
+            stats: stat,
+            convertedInvested: convertedStats[asset.id],
+            marketValue: marketValues[asset.id],
+            baseCurrency: baseCurrency,
+            locale: locale,
+            strings: s,
+            intermediaries: intermediaries,
+            onMove: (newId) {
+              if (newId != asset.intermediaryId) {
+                ref.read(intermediaryServiceProvider).moveAsset(asset.id, newId);
+              }
+            },
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => AssetDetailScreen(asset: asset)),
+            ),
+          );
+        }),
+        const Divider(height: 1),
+      ],
     );
   }
 
@@ -385,6 +335,8 @@ class _AssetTile extends StatelessWidget {
   final String locale;
   final VoidCallback onTap;
   final AppStrings strings;
+  final List<Intermediary> intermediaries;
+  final void Function(int? newIntermediaryId) onMove;
 
   const _AssetTile({
     super.key,
@@ -396,6 +348,8 @@ class _AssetTile extends StatelessWidget {
     required this.locale,
     required this.onTap,
     required this.strings,
+    required this.intermediaries,
+    required this.onMove,
   });
 
   @override
@@ -544,7 +498,46 @@ class _AssetTile extends StatelessWidget {
               ],
             ),
             const SizedBox(width: 4),
-            const Icon(Icons.chevron_right, size: 18, color: Colors.grey),
+            PopupMenuButton<int?>(
+              icon: const Icon(Icons.more_vert, size: 20, color: Colors.grey),
+              tooltip: strings.selectIntermediary,
+              itemBuilder: (_) => <PopupMenuEntry<int?>>[
+                PopupMenuItem<int?>(
+                  enabled: false,
+                  child: Text(
+                    strings.selectIntermediary,
+                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                ),
+                const PopupMenuDivider(),
+                for (final i in intermediaries)
+                  PopupMenuItem<int?>(
+                    value: i.id,
+                    child: Row(
+                      children: [
+                        const Icon(Icons.business, size: 18),
+                        const SizedBox(width: 8),
+                        Expanded(child: Text(i.name)),
+                        if (asset.intermediaryId == i.id)
+                          const Icon(Icons.check, size: 18),
+                      ],
+                    ),
+                  ),
+                PopupMenuItem<int?>(
+                  value: null,
+                  child: Row(
+                    children: [
+                      const Icon(Icons.folder_open, size: 18),
+                      const SizedBox(width: 8),
+                      Expanded(child: Text(strings.unassigned)),
+                      if (asset.intermediaryId == null)
+                        const Icon(Icons.check, size: 18),
+                    ],
+                  ),
+                ),
+              ],
+              onSelected: onMove,
+            ),
           ],
         ),
       ),

--- a/lib/ui/screens/assets_screen.dart
+++ b/lib/ui/screens/assets_screen.dart
@@ -17,6 +17,9 @@ import '../../utils/formatters.dart' as fmt;
 import 'asset_detail_screen.dart';
 import 'dashboard/dashboard_screen.dart' show currencySymbol;
 import '../widgets/privacy_text.dart';
+import '../widgets/selection/selectable_item.dart';
+import '../widgets/selection/selection_action_bar.dart';
+import '../widgets/selection/selection_controller.dart';
 
 class AssetsScreen extends ConsumerStatefulWidget {
   const AssetsScreen({super.key});
@@ -26,6 +29,14 @@ class AssetsScreen extends ConsumerStatefulWidget {
 }
 
 class _AssetsScreenState extends ConsumerState<AssetsScreen> {
+  final _selection = SelectionController<int>();
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final s = ref.watch(appStringsProvider);
@@ -37,7 +48,24 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
     final convertedStats = ref.watch(convertedAssetStatsProvider).value ?? {};
     final marketValues = ref.watch(assetMarketValuesProvider).value ?? {};
 
-    return Scaffold(
+    return ListenableBuilder(
+      listenable: _selection,
+      builder: (lbCtx, _) {
+        // Build the id list in rendered order: grouped by intermediary, then
+        // unassigned last. This matches what _buildGroup actually displays
+        // and is what range-select on long-press needs.
+        final assets = assetsAsync.value ?? const <Asset>[];
+        final intermediariesNow = intermediariesAsync.value ?? const <Intermediary>[];
+        final grouping = <int?, List<int>>{};
+        for (final a in assets) {
+          (grouping[a.intermediaryId] ??= []).add(a.id);
+        }
+        final allAssetIds = <int>[
+          for (final i in intermediariesNow) ...?grouping[i.id],
+          ...?grouping[null],
+        ];
+        _selection.setOrderedIds(allAssetIds);
+        return Scaffold(
       body: assetsAsync.when(
         data: (assets) {
           if (assets.isEmpty && (intermediariesAsync.value ?? []).isEmpty) {
@@ -93,25 +121,36 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text(s.error(e))),
       ),
-      floatingActionButton: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          FloatingActionButton.small(
-            heroTag: 'add_intermediary_assets',
-            onPressed: () => _showManageIntermediariesDialog(context),
-            child: const Icon(Icons.business),
-          ),
-          const SizedBox(height: 8),
-          FloatingActionButton(
-            heroTag: 'add_asset',
-            onPressed: () => showDialog(
-              context: context,
-              builder: (ctx) => _CreateAssetDialog(ref: ref),
+      bottomNavigationBar: _selection.active
+          ? SelectionActionBar<int>(
+              controller: _selection,
+              visibleIds: allAssetIds,
+              onDelete: (ids) => ref.read(assetServiceProvider).deleteMany(ids.toList()),
+            )
+          : null,
+      floatingActionButton: _selection.active
+          ? null
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FloatingActionButton.small(
+                  heroTag: 'add_intermediary_assets',
+                  onPressed: () => _showManageIntermediariesDialog(context),
+                  child: const Icon(Icons.business),
+                ),
+                const SizedBox(height: 8),
+                FloatingActionButton(
+                  heroTag: 'add_asset',
+                  onPressed: () => showDialog(
+                    context: context,
+                    builder: (ctx) => _CreateAssetDialog(ref: ref),
+                  ),
+                  child: const Icon(Icons.add),
+                ),
+              ],
             ),
-            child: const Icon(Icons.add),
-          ),
-        ],
-      ),
+    );
+      },
     );
   }
 
@@ -157,24 +196,28 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
         ),
         ...assets.map((asset) {
           final stat = stats[asset.id];
-          return _AssetTile(
+          return SelectableItem<int>(
             key: ValueKey(asset.id),
-            asset: asset,
-            stats: stat,
-            convertedInvested: convertedStats[asset.id],
-            marketValue: marketValues[asset.id],
-            baseCurrency: baseCurrency,
-            locale: locale,
-            strings: s,
-            intermediaries: intermediaries,
-            onMove: (newId) {
-              if (newId != asset.intermediaryId) {
-                ref.read(intermediaryServiceProvider).moveAsset(asset.id, newId);
-              }
-            },
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(builder: (_) => AssetDetailScreen(asset: asset)),
+            controller: _selection,
+            id: asset.id,
+            child: _AssetTile(
+              asset: asset,
+              stats: stat,
+              convertedInvested: convertedStats[asset.id],
+              marketValue: marketValues[asset.id],
+              baseCurrency: baseCurrency,
+              locale: locale,
+              strings: s,
+              intermediaries: intermediaries,
+              onMove: (newId) {
+                if (newId != asset.intermediaryId) {
+                  ref.read(intermediaryServiceProvider).moveAsset(asset.id, newId);
+                }
+              },
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => AssetDetailScreen(asset: asset)),
+              ),
             ),
           );
         }),
@@ -339,7 +382,6 @@ class _AssetTile extends StatelessWidget {
   final void Function(int? newIntermediaryId) onMove;
 
   const _AssetTile({
-    super.key,
     required this.asset,
     required this.stats,
     this.convertedInvested,

--- a/lib/ui/screens/capex_screen.dart
+++ b/lib/ui/screens/capex_screen.dart
@@ -13,6 +13,9 @@ import 'income_adj_detail_screen.dart';
 import 'income_adj_edit_screen.dart';
 import 'dashboard/dashboard_screen.dart' show currencySymbol;
 import '../widgets/privacy_text.dart';
+import '../widgets/selection/selectable_item.dart';
+import '../widgets/selection/selection_action_bar.dart';
+import '../widgets/selection/selection_controller.dart';
 
 class CapexScreen extends ConsumerWidget {
   const CapexScreen({super.key});
@@ -50,62 +53,95 @@ class CapexScreen extends ConsumerWidget {
 // Spread tab (existing CAPEX adjustments)
 // ════════════════════════════════════════════════════
 
-class _SpreadTab extends ConsumerWidget {
+class _SpreadTab extends ConsumerStatefulWidget {
   const _SpreadTab();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_SpreadTab> createState() => _SpreadTabState();
+}
+
+class _SpreadTabState extends ConsumerState<_SpreadTab> {
+  final _selection = SelectionController<int>();
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final s = ref.watch(appStringsProvider);
     final schedulesAsync = ref.watch(capexSchedulesProvider);
     final statsAsync = ref.watch(capexStatsProvider);
     final baseCurrency = ref.watch(baseCurrencyProvider).value ?? 'EUR';
     final locale = ref.watch(appLocaleProvider).value ?? Platform.localeName;
 
-    return Scaffold(
-      body: schedulesAsync.when(
-        data: (schedules) {
-          if (schedules.isEmpty) {
-            return Center(
-              child: Text(s.noSpreadAdjustments,
-                  textAlign: TextAlign.center),
-            );
-          }
+    return ListenableBuilder(
+      listenable: _selection,
+      builder: (ctx, _) {
+        final schedules = schedulesAsync.value ?? const <DepreciationSchedule>[];
+        _selection.setOrderedIds(schedules.map((s) => s.id).toList());
+        return Scaffold(
+          body: schedulesAsync.when(
+            data: (schedules) {
+              if (schedules.isEmpty) {
+                return Center(
+                  child: Text(s.noSpreadAdjustments,
+                      textAlign: TextAlign.center),
+                );
+              }
 
-          final stats = statsAsync.value ?? {};
+              final stats = statsAsync.value ?? {};
 
-          return ListView.separated(
-            itemCount: schedules.length,
-            separatorBuilder: (_, _) => const Divider(height: 1),
-            itemBuilder: (ctx, i) {
-              final schedule = schedules[i];
-              final stat = stats[schedule.id];
+              return ListView.separated(
+                itemCount: schedules.length,
+                separatorBuilder: (_, _) => const Divider(height: 1),
+                itemBuilder: (ctx, i) {
+                  final schedule = schedules[i];
+                  final stat = stats[schedule.id];
 
-              return _CapexTile(
-                schedule: schedule,
-                stats: stat,
-                baseCurrency: baseCurrency,
-                locale: locale,
-                strings: s,
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => CapexDetailScreen(scheduleId: schedule.id),
-                  ),
-                ),
+                  return SelectableItem<int>(
+                    controller: _selection,
+                    id: schedule.id,
+                    child: _CapexTile(
+                      schedule: schedule,
+                      stats: stat,
+                      baseCurrency: baseCurrency,
+                      locale: locale,
+                      strings: s,
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => CapexDetailScreen(scheduleId: schedule.id),
+                        ),
+                      ),
+                    ),
+                  );
+                },
               );
             },
-          );
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text(s.error(e))),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const CapexEditScreen()),
-        ),
-        child: const Icon(Icons.add),
-      ),
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, _) => Center(child: Text(s.error(e))),
+          ),
+          bottomNavigationBar: _selection.active
+              ? SelectionActionBar<int>(
+                  controller: _selection,
+                  visibleIds: schedules.map((s) => s.id).toList(),
+                  onDelete: (ids) => ref.read(capexServiceProvider).deleteMany(ids.toList()),
+                )
+              : null,
+          floatingActionButton: _selection.active
+              ? null
+              : FloatingActionButton(
+                  onPressed: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const CapexEditScreen()),
+                  ),
+                  child: const Icon(Icons.add),
+                ),
+        );
+      },
     );
   }
 }
@@ -114,51 +150,84 @@ class _SpreadTab extends ConsumerWidget {
 // Income tab (income/donation adjustments)
 // ════════════════════════════════════════════════════
 
-class _IncomeTab extends ConsumerWidget {
+class _IncomeTab extends ConsumerStatefulWidget {
   const _IncomeTab();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_IncomeTab> createState() => _IncomeTabState();
+}
+
+class _IncomeTabState extends ConsumerState<_IncomeTab> {
+  final _selection = SelectionController<int>();
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final s = ref.watch(appStringsProvider);
     final adjAsync = ref.watch(incomeAdjustmentsProvider);
 
-    return Scaffold(
-      body: adjAsync.when(
-        data: (adjustments) {
-          if (adjustments.isEmpty) {
-            return Center(
-              child: Text(s.noIncomeAdjustments,
-                  textAlign: TextAlign.center),
-            );
-          }
+    return ListenableBuilder(
+      listenable: _selection,
+      builder: (ctx, _) {
+        final adjustments = adjAsync.value ?? const <IncomeAdjustment>[];
+        _selection.setOrderedIds(adjustments.map((a) => a.id).toList());
+        return Scaffold(
+          body: adjAsync.when(
+            data: (adjustments) {
+              if (adjustments.isEmpty) {
+                return Center(
+                  child: Text(s.noIncomeAdjustments,
+                      textAlign: TextAlign.center),
+                );
+              }
 
-          return ListView.separated(
-            itemCount: adjustments.length,
-            separatorBuilder: (_, _) => const Divider(height: 1),
-            itemBuilder: (ctx, i) {
-              final adj = adjustments[i];
-              return _IncomeAdjTile(
-                adjustment: adj,
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => IncomeAdjDetailScreen(adjustmentId: adj.id),
-                  ),
-                ),
+              return ListView.separated(
+                itemCount: adjustments.length,
+                separatorBuilder: (_, _) => const Divider(height: 1),
+                itemBuilder: (ctx, i) {
+                  final adj = adjustments[i];
+                  return SelectableItem<int>(
+                    controller: _selection,
+                    id: adj.id,
+                    child: _IncomeAdjTile(
+                      adjustment: adj,
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => IncomeAdjDetailScreen(adjustmentId: adj.id),
+                        ),
+                      ),
+                    ),
+                  );
+                },
               );
             },
-          );
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text(s.error(e))),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const IncomeAdjEditScreen()),
-        ),
-        child: const Icon(Icons.add),
-      ),
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, _) => Center(child: Text(s.error(e))),
+          ),
+          bottomNavigationBar: _selection.active
+              ? SelectionActionBar<int>(
+                  controller: _selection,
+                  visibleIds: adjustments.map((a) => a.id).toList(),
+                  onDelete: (ids) => ref.read(incomeAdjustmentServiceProvider).deleteMany(ids.toList()),
+                )
+              : null,
+          floatingActionButton: _selection.active
+              ? null
+              : FloatingActionButton(
+                  onPressed: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const IncomeAdjEditScreen()),
+                  ),
+                  child: const Icon(Icons.add),
+                ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/screens/income_screen.dart
+++ b/lib/ui/screens/income_screen.dart
@@ -13,6 +13,9 @@ import '../../utils/formatters.dart' as fmt;
 import 'dashboard/dashboard_screen.dart' show currencySymbol;
 import 'import/import_screen.dart';
 import '../widgets/privacy_text.dart';
+import '../widgets/selection/selectable_item.dart';
+import '../widgets/selection/selection_action_bar.dart';
+import '../widgets/selection/selection_controller.dart';
 
 class IncomeScreen extends ConsumerStatefulWidget {
   const IncomeScreen({super.key});
@@ -24,10 +27,12 @@ class IncomeScreen extends ConsumerStatefulWidget {
 class _IncomeScreenState extends ConsumerState<IncomeScreen> {
   String get _locale => ref.read(appLocaleProvider).value ?? Platform.localeName;
   final _focusNode = FocusNode();
+  final _selection = SelectionController<int>();
 
   @override
   void dispose() {
     _focusNode.dispose();
+    _selection.dispose();
     super.dispose();
   }
 
@@ -171,78 +176,98 @@ class _IncomeScreenState extends ConsumerState<IncomeScreen> {
           _handlePaste();
         }
       },
-      child: Scaffold(
-        body: incomesAsync.when(
-          data: (incomes) {
-            if (incomes.isEmpty) {
-              return Center(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.payments, size: 48, color: Theme.of(context).colorScheme.onSurfaceVariant),
-                    const SizedBox(height: 16),
-                    Text(s.noIncomeYet, textAlign: TextAlign.center),
-                    const SizedBox(height: 16),
-                    FilledButton.icon(
-                      onPressed: () => _showAddDialog(context, baseCurrency),
-                      icon: const Icon(Icons.add),
-                      label: Text(s.addIncomeTitle),
+      child: ListenableBuilder(
+        listenable: _selection,
+        builder: (ctx, _) {
+          final incomes = incomesAsync.value ?? const <Income>[];
+          _selection.setOrderedIds(incomes.map((i) => i.id).toList());
+          return Scaffold(
+            body: incomesAsync.when(
+              data: (incomes) {
+                if (incomes.isEmpty) {
+                  return Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.payments, size: 48, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                        const SizedBox(height: 16),
+                        Text(s.noIncomeYet, textAlign: TextAlign.center),
+                        const SizedBox(height: 16),
+                        FilledButton.icon(
+                          onPressed: () => _showAddDialog(context, baseCurrency),
+                          icon: const Icon(Icons.add),
+                          label: Text(s.addIncomeTitle),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-              );
-            }
+                  );
+                }
 
-            return ListView.separated(
-              itemCount: incomes.length,
-              separatorBuilder: (_, _) => const Divider(height: 1),
-              itemBuilder: (ctx, i) {
-                final income = incomes[i];
-                final sym = currencySymbol(income.currency);
-                return ListTile(
-                  leading: CircleAvatar(
-                    backgroundColor: _typeColor(context, income.type),
-                    child: Icon(
-                      _typeIcon(income.type),
-                      color: _typeIconColor(context, income.type),
-                    ),
-                  ),
-                  title: PrivacyText(
-                    '${amtFormat.format(income.amount)} $sym',
-                    style: const TextStyle(fontWeight: FontWeight.w600),
-                  ),
-                  subtitle: Text(
-                    '${dateFmt.format(income.date)} · ${_typeLabel(s, income.type)}',
-                  ),
-                  trailing: Text(income.currency, style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant, fontSize: 12)),
-                  onTap: () => _showEditDialog(context, income),
+                return ListView.separated(
+                  itemCount: incomes.length,
+                  separatorBuilder: (_, _) => const Divider(height: 1),
+                  itemBuilder: (ctx, i) {
+                    final income = incomes[i];
+                    final sym = currencySymbol(income.currency);
+                    return SelectableItem<int>(
+                      controller: _selection,
+                      id: income.id,
+                      child: ListTile(
+                        leading: CircleAvatar(
+                          backgroundColor: _typeColor(context, income.type),
+                          child: Icon(
+                            _typeIcon(income.type),
+                            color: _typeIconColor(context, income.type),
+                          ),
+                        ),
+                        title: PrivacyText(
+                          '${amtFormat.format(income.amount)} $sym',
+                          style: const TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                        subtitle: Text(
+                          '${dateFmt.format(income.date)} · ${_typeLabel(s, income.type)}',
+                        ),
+                        trailing: Text(income.currency, style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant, fontSize: 12)),
+                        onTap: () => _showEditDialog(context, income),
+                      ),
+                    );
+                  },
                 );
               },
-            );
-          },
-          loading: () => const Center(child: CircularProgressIndicator()),
-          error: (e, _) => Center(child: Text(s.error(e))),
-        ),
-        floatingActionButton: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            FloatingActionButton.small(
-              heroTag: 'import',
-              tooltip: s.importFromFileTooltip,
-              onPressed: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const ImportScreen(preselectedTarget: ImportTarget.income)),
-              ),
-              child: const Icon(Icons.file_upload),
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text(s.error(e))),
             ),
-            const SizedBox(height: 8),
-            FloatingActionButton(
-              heroTag: 'add',
-              onPressed: () => _showAddDialog(context, baseCurrency),
-              child: const Icon(Icons.add),
-            ),
-          ],
-        ),
+            bottomNavigationBar: _selection.active
+                ? SelectionActionBar<int>(
+                    controller: _selection,
+                    visibleIds: incomes.map((i) => i.id).toList(),
+                    onDelete: (ids) => ref.read(incomeServiceProvider).deleteMany(ids.toList()),
+                  )
+                : null,
+            floatingActionButton: _selection.active
+                ? null
+                : Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      FloatingActionButton.small(
+                        heroTag: 'import',
+                        tooltip: s.importFromFileTooltip,
+                        onPressed: () => Navigator.push(
+                          context,
+                          MaterialPageRoute(builder: (_) => const ImportScreen(preselectedTarget: ImportTarget.income)),
+                        ),
+                        child: const Icon(Icons.file_upload),
+                      ),
+                      const SizedBox(height: 8),
+                      FloatingActionButton(
+                        heroTag: 'add',
+                        onPressed: () => _showAddDialog(context, baseCurrency),
+                        child: const Icon(Icons.add),
+                      ),
+                    ],
+                  ),
+          );
+        },
       ),
     );
   }

--- a/lib/ui/widgets/selection/selectable_item.dart
+++ b/lib/ui/widgets/selection/selectable_item.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import 'selection_controller.dart';
+
+/// Wraps any list-item widget with the gesture + visual layer needed for
+/// multi-select mode. Adds:
+///
+///   * long-press → [SelectionController.enter]
+///   * single tap while active → [SelectionController.toggle]
+///   * tinted background + check-circle overlay when selected
+///   * pointer-event suppression of the child's own `onTap` while active
+///
+/// The child is rendered verbatim (no layout reshuffling, no theme changes)
+/// so every call site can keep its existing tile widget exactly as-is.
+class SelectableItem<T> extends StatelessWidget {
+  final SelectionController<T> controller;
+  final T id;
+  final Widget child;
+
+  const SelectableItem({
+    super.key,
+    required this.controller,
+    required this.id,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (ctx, _) {
+        final selected = controller.contains(id);
+        final active = controller.active;
+
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          // Long-press is always wired so the user can start selection mode.
+          onLongPress: () => controller.enter(id),
+          // Single tap routes through the controller while selection is
+          // active; otherwise the child's own onTap handler runs (because we
+          // only enable IgnorePointer when active).
+          onTap: active ? () => controller.toggle(id) : null,
+          child: Stack(
+            children: [
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 120),
+                color: selected
+                    ? Theme.of(ctx).colorScheme.primaryContainer.withValues(alpha: 0.4)
+                    : Colors.transparent,
+                child: IgnorePointer(
+                  ignoring: active,
+                  child: child,
+                ),
+              ),
+              if (selected)
+                const Positioned(
+                  left: 4,
+                  top: 0,
+                  bottom: 0,
+                  child: Center(
+                    child: Icon(Icons.check_circle, size: 20, color: Colors.blue),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/widgets/selection/selection_action_bar.dart
+++ b/lib/ui/widgets/selection/selection_action_bar.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_strings.dart';
+import '../../../services/providers/providers.dart';
+import 'selection_controller.dart';
+
+/// Persistent bottom action bar shown while a [SelectionController] is active.
+///
+/// Each list screen uses this in its `Scaffold.bottomNavigationBar` slot,
+/// gated on `controller.active`. The bar is the single place that renders
+/// the count label, select-all / deselect-all toggle, cancel (X) button, and
+/// the bulk-delete confirmation dialog — no per-screen duplication.
+class SelectionActionBar<T> extends ConsumerWidget {
+  final SelectionController<T> controller;
+
+  /// All currently-visible ids on the screen (after any filter / search).
+  /// Used for "select all" and to flip the label to "deselect all" when
+  /// everything visible is already selected.
+  final List<T> visibleIds;
+
+  /// Async bulk-delete callback. Called only after the user confirms the
+  /// dialog. On success, the controller is cleared automatically.
+  final Future<void> Function(Set<T> ids) onDelete;
+
+  const SelectionActionBar({
+    super.key,
+    required this.controller,
+    required this.visibleIds,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final s = ref.watch(appStringsProvider);
+    final theme = Theme.of(context);
+
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (ctx, _) {
+        final count = controller.count;
+        final allVisibleSelected = visibleIds.isNotEmpty &&
+            visibleIds.every(controller.contains);
+
+        return Material(
+          elevation: 8,
+          color: theme.colorScheme.surfaceContainerHighest,
+          child: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    tooltip: s.cancel,
+                    onPressed: controller.clear,
+                  ),
+                  const SizedBox(width: 4),
+                  Expanded(
+                    child: Text(
+                      s.nSelected(count),
+                      style: theme.textTheme.titleSmall,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  TextButton.icon(
+                    icon: Icon(allVisibleSelected
+                        ? Icons.deselect
+                        : Icons.select_all),
+                    label: Text(allVisibleSelected ? s.deselectAll : s.selectAll),
+                    onPressed: visibleIds.isEmpty
+                        ? null
+                        : () {
+                            if (allVisibleSelected) {
+                              controller.clear();
+                            } else {
+                              controller.selectAll(visibleIds);
+                            }
+                          },
+                  ),
+                  const SizedBox(width: 4),
+                  IconButton(
+                    icon: Icon(Icons.delete, color: theme.colorScheme.error),
+                    tooltip: s.delete,
+                    onPressed: count == 0 ? null : () => _confirmAndDelete(ctx, s),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _confirmAndDelete(BuildContext context, AppStrings s) async {
+    final count = controller.count;
+    final ids = controller.ids;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(s.bulkDeleteTitle),
+        content: Text(s.bulkDeleteBody(count)),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: Text(s.cancel)),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(s.delete),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    await onDelete(ids);
+    controller.clear();
+  }
+}

--- a/lib/ui/widgets/selection/selection_controller.dart
+++ b/lib/ui/widgets/selection/selection_controller.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/foundation.dart';
+
+/// Tracks the set of currently-selected item ids for one list screen.
+///
+/// One controller is created per screen that supports multi-select and lives
+/// for the screen's lifetime. It is a [ChangeNotifier] so widgets can rebuild
+/// via [ListenableBuilder] when the selection changes.
+class SelectionController<T> extends ChangeNotifier {
+  final Set<T> _selected = <T>{};
+
+  /// The currently-visible ids in their display order. Used by [enter] to
+  /// expand a long-press into a range when selection is already active.
+  /// Hint only — setting this never notifies listeners, so it is safe to
+  /// call from inside a build() method.
+  List<T>? _orderedIds;
+
+  void setOrderedIds(List<T> orderedIds) {
+    _orderedIds = orderedIds;
+  }
+
+  /// True when at least one item is selected (i.e. selection mode is active).
+  bool get active => _selected.isNotEmpty;
+
+  int get count => _selected.length;
+
+  /// Read-only view of the current selection.
+  Set<T> get ids => Set.unmodifiable(_selected);
+
+  bool contains(T id) => _selected.contains(id);
+
+  /// Entry point for a long-press.
+  ///
+  /// If selection mode is not yet active, simply adds [id] and starts the
+  /// mode. If it IS active and an [setOrderedIds] hint has been provided,
+  /// long-pressing expands the selection to cover the range from [id] to the
+  /// furthest already-selected item (inclusive, by index distance). Without
+  /// an ordered-ids hint this falls back to a simple add.
+  void enter(T id) {
+    if (_selected.isEmpty || _orderedIds == null) {
+      if (_selected.add(id)) notifyListeners();
+      return;
+    }
+
+    final ordered = _orderedIds!;
+    final pressedIdx = ordered.indexOf(id);
+    if (pressedIdx < 0) {
+      // Pressed id is not in the current visible list — no range to expand.
+      if (_selected.add(id)) notifyListeners();
+      return;
+    }
+
+    int? furthestIdx;
+    var furthestDistance = -1;
+    for (var i = 0; i < ordered.length; i++) {
+      if (!_selected.contains(ordered[i])) continue;
+      final d = (i - pressedIdx).abs();
+      if (d > furthestDistance) {
+        furthestDistance = d;
+        furthestIdx = i;
+      }
+    }
+
+    if (furthestIdx == null) {
+      if (_selected.add(id)) notifyListeners();
+      return;
+    }
+
+    final start = pressedIdx < furthestIdx ? pressedIdx : furthestIdx;
+    final end = pressedIdx < furthestIdx ? furthestIdx : pressedIdx;
+    var changed = false;
+    for (var i = start; i <= end; i++) {
+      if (_selected.add(ordered[i])) changed = true;
+    }
+    if (changed) notifyListeners();
+  }
+
+  /// Tap while active: toggles [id]. If the last selected item is toggled
+  /// off, [active] becomes false and listeners are still notified.
+  void toggle(T id) {
+    if (!_selected.remove(id)) _selected.add(id);
+    notifyListeners();
+  }
+
+  /// Cancel button or post-delete cleanup. No-op if already empty.
+  void clear() {
+    if (_selected.isEmpty) return;
+    _selected.clear();
+    notifyListeners();
+  }
+
+  /// Replaces the current selection with [all]. Callers pass the currently
+  /// visible ids on the screen (after any search / filter applied).
+  void selectAll(Iterable<T> all) {
+    _selected
+      ..clear()
+      ..addAll(all);
+    notifyListeners();
+  }
+}

--- a/test/account_service_test.dart
+++ b/test/account_service_test.dart
@@ -138,6 +138,39 @@ void main() {
     });
   });
 
+  group('deleteMany', () {
+    test('empty list is a no-op', () async {
+      await service.create(name: 'Keep', currency: 'EUR');
+      final n = await service.deleteMany([]);
+      expect(n, 0);
+      expect((await service.getAll()).length, 1);
+    });
+
+    test('removes multiple accounts and cascades their transactions', () async {
+      final a = await service.create(name: 'A', currency: 'EUR');
+      final b = await service.create(name: 'B', currency: 'EUR');
+      final keep = await service.create(name: 'Keep', currency: 'EUR');
+
+      for (final id in [a, b, keep]) {
+        await db.into(db.transactions).insert(TransactionsCompanion.insert(
+              accountId: id,
+              operationDate: DateTime(2024, 1, 1),
+              valueDate: DateTime(2024, 1, 1),
+              amount: 100.0,
+            ));
+      }
+
+      final n = await service.deleteMany([a, b]);
+      expect(n, 2);
+
+      final remainingAccounts = await service.getAll();
+      expect(remainingAccounts.map((x) => x.id), [keep]);
+
+      final remainingTx = await db.select(db.transactions).get();
+      expect(remainingTx.map((t) => t.accountId).toSet(), {keep});
+    });
+  });
+
   group('reorder', () {
     test('reorder updates sortOrder for all accounts', () async {
       final id1 = await service.create(name: 'A', currency: 'EUR');

--- a/test/asset_event_service_test.dart
+++ b/test/asset_event_service_test.dart
@@ -198,6 +198,40 @@ void main() {
       final events = await service.getByAsset(assetId);
       expect(events, isEmpty);
     });
+
+    test('deleteMany empty list is a no-op', () async {
+      final assetId = await createAsset('Keep');
+      await service.create(
+        assetId: assetId,
+        date: DateTime(2024, 1, 1),
+        type: EventType.buy,
+        amount: 100.0,
+        currency: 'EUR',
+      );
+      expect(await service.deleteMany([]), 0);
+      expect((await service.getByAsset(assetId)).length, 1);
+    });
+
+    test('deleteMany removes only the given event ids', () async {
+      final assetId = await createAsset('Multi');
+      final a = await service.create(
+        assetId: assetId, date: DateTime(2024, 1, 1),
+        type: EventType.buy, amount: 100.0, currency: 'EUR',
+      );
+      final b = await service.create(
+        assetId: assetId, date: DateTime(2024, 2, 1),
+        type: EventType.buy, amount: 200.0, currency: 'EUR',
+      );
+      final c = await service.create(
+        assetId: assetId, date: DateTime(2024, 3, 1),
+        type: EventType.buy, amount: 300.0, currency: 'EUR',
+      );
+
+      expect(await service.deleteMany([a, c]), 2);
+
+      final remaining = await service.getByAsset(assetId);
+      expect(remaining.map((e) => e.id), [b]);
+    });
   });
 
   group('event types', () {

--- a/test/asset_service_test.dart
+++ b/test/asset_service_test.dart
@@ -135,6 +135,67 @@ void main() {
     });
   });
 
+  group('deleteMany', () {
+    test('empty list is a no-op', () async {
+      await service.create(name: 'Keep', currency: 'EUR');
+      final n = await service.deleteMany([]);
+      expect(n, 0);
+      expect((await service.getAll()).length, 1);
+    });
+
+    test('removes multiple assets in one call', () async {
+      final a = await service.create(name: 'A', currency: 'EUR');
+      final b = await service.create(name: 'B', currency: 'EUR');
+      final c = await service.create(name: 'C', currency: 'EUR');
+
+      final n = await service.deleteMany([a, c]);
+      expect(n, 2);
+
+      final remaining = await service.getAll();
+      expect(remaining.map((x) => x.id), [b]);
+    });
+
+    test('cascades events, snapshots and prices for all deleted assets', () async {
+      final a = await service.create(name: 'A', currency: 'EUR');
+      final b = await service.create(name: 'B', currency: 'EUR');
+      final keep = await service.create(name: 'Keep', currency: 'EUR');
+
+      for (final id in [a, b, keep]) {
+        await db.into(db.assetEvents).insert(AssetEventsCompanion.insert(
+              assetId: id,
+              date: DateTime(2024, 1, 1),
+              valueDate: DateTime(2024, 1, 1),
+              type: EventType.buy,
+              amount: 100.0,
+            ));
+        await db.into(db.assetSnapshots).insert(AssetSnapshotsCompanion.insert(
+              assetId: id,
+              date: DateTime(2024, 1, 1),
+              value: 100.0,
+              invested: 90.0,
+              growth: 10.0,
+              growthPercent: 0.11,
+              afterTaxValue: 97.0,
+            ));
+        await db.into(db.marketPrices).insert(MarketPricesCompanion.insert(
+              assetId: id,
+              date: DateTime(2024, 1, 1),
+              closePrice: 10.0,
+              currency: 'EUR',
+            ));
+      }
+
+      await service.deleteMany([a, b]);
+
+      final remainingEvents = await db.select(db.assetEvents).get();
+      expect(remainingEvents.map((e) => e.assetId).toSet(), {keep});
+      final remainingSnapshots = await db.select(db.assetSnapshots).get();
+      expect(remainingSnapshots.map((s) => s.assetId).toSet(), {keep});
+      final remainingPrices = await db.select(db.marketPrices).get();
+      expect(remainingPrices.map((p) => p.assetId).toSet(), {keep});
+    });
+  });
+
   group('reorder', () {
     test('reorder updates sortOrder', () async {
       final id1 = await service.create(name: 'A', currency: 'EUR');

--- a/test/capex_service_test.dart
+++ b/test/capex_service_test.dart
@@ -99,6 +99,39 @@ void main() {
       expect(schedules, isEmpty);
     });
 
+    test('deleteMany empty list is a no-op', () async {
+      await service.create(
+        name: 'Keep', totalAmount: 100, currency: 'EUR',
+        startDate: DateTime(2024, 1, 1), endDate: DateTime(2024, 3, 1),
+      );
+      expect(await service.deleteMany([]), 0);
+      expect((await service.getAll()).length, 1);
+    });
+
+    test('deleteMany removes multiple schedules and their entries', () async {
+      final a = await service.create(
+        name: 'A', totalAmount: 300, currency: 'EUR',
+        startDate: DateTime(2024, 1, 1), endDate: DateTime(2024, 3, 1),
+      );
+      final b = await service.create(
+        name: 'B', totalAmount: 300, currency: 'EUR',
+        startDate: DateTime(2024, 1, 1), endDate: DateTime(2024, 3, 1),
+      );
+      final keep = await service.create(
+        name: 'Keep', totalAmount: 300, currency: 'EUR',
+        startDate: DateTime(2024, 1, 1), endDate: DateTime(2024, 3, 1),
+      );
+
+      expect(await service.deleteMany([a, b]), 2);
+
+      final remaining = await service.getAll();
+      expect(remaining.map((s) => s.id), [keep]);
+
+      // Entries for the deleted schedules are also gone.
+      final allEntries = await db.select(db.depreciationEntries).get();
+      expect(allEntries.every((e) => e.scheduleId == keep), isTrue);
+    });
+
     test('entries ordered asc by date', () async {
       final id = await service.create(
         name: 'Keyboard',

--- a/test/income_adjustment_service_test.dart
+++ b/test/income_adjustment_service_test.dart
@@ -114,6 +114,45 @@ void main() {
       final allExpenses = await db.select(db.incomeAdjustmentExpenses).get();
       expect(allExpenses, isEmpty);
     });
+
+    test('deleteMany empty list is a no-op', () async {
+      await service.create(
+        name: 'Keep', totalAmount: 1000, currency: 'EUR',
+        incomeDate: DateTime(2024, 1, 1),
+      );
+      expect(await service.deleteMany([]), 0);
+      expect((await service.getAll()).length, 1);
+    });
+
+    test('deleteMany removes multiple adjustments and cascades expenses', () async {
+      final a = await service.create(
+        name: 'A', totalAmount: 1000, currency: 'EUR',
+        incomeDate: DateTime(2024, 1, 1),
+      );
+      final b = await service.create(
+        name: 'B', totalAmount: 1000, currency: 'EUR',
+        incomeDate: DateTime(2024, 1, 1),
+      );
+      final keep = await service.create(
+        name: 'Keep', totalAmount: 1000, currency: 'EUR',
+        incomeDate: DateTime(2024, 1, 1),
+      );
+
+      for (final id in [a, b, keep]) {
+        await service.addExpense(
+          adjustmentId: id,
+          date: DateTime(2024, 2, 1),
+          amount: 100,
+          description: 'x',
+        );
+      }
+
+      expect(await service.deleteMany([a, b]), 2);
+      expect((await service.getAll()).map((x) => x.id), [keep]);
+
+      final remainingExpenses = await db.select(db.incomeAdjustmentExpenses).get();
+      expect(remainingExpenses.every((e) => e.adjustmentId == keep), isTrue);
+    });
   });
 
   group('Expenses CRUD', () {

--- a/test/income_service_test.dart
+++ b/test/income_service_test.dart
@@ -88,6 +88,23 @@ void main() {
       final all = await service.getAll();
       expect(all, isEmpty);
     });
+
+    test('deleteMany empty list is a no-op', () async {
+      await service.create(date: DateTime(2024, 1, 1), amount: 1000, currency: 'EUR');
+      expect(await service.deleteMany([]), 0);
+      expect((await service.getAll()).length, 1);
+    });
+
+    test('deleteMany removes only the given income ids', () async {
+      final a = await service.create(date: DateTime(2024, 1, 1), amount: 100, currency: 'EUR');
+      final b = await service.create(date: DateTime(2024, 1, 2), amount: 200, currency: 'EUR');
+      final c = await service.create(date: DateTime(2024, 1, 3), amount: 300, currency: 'EUR');
+
+      expect(await service.deleteMany([a, c]), 2);
+
+      final remaining = await service.getAll();
+      expect(remaining.map((i) => i.id), [b]);
+    });
   });
 
   group('Bulk create', () {

--- a/test/transaction_service_test.dart
+++ b/test/transaction_service_test.dart
@@ -158,6 +158,39 @@ void main() {
       final txs = await service.getByAccount(accountId);
       expect(txs, isEmpty);
     });
+
+    test('deleteMany empty list is a no-op', () async {
+      final accountId = await createAccount('Keep');
+      await service.create(
+        accountId: accountId,
+        operationDate: DateTime(2024, 1, 1),
+        amount: 100.0,
+        currency: 'EUR',
+      );
+      expect(await service.deleteMany([]), 0);
+      expect((await service.getByAccount(accountId)).length, 1);
+    });
+
+    test('deleteMany removes only the given transaction ids', () async {
+      final accountId = await createAccount('Multi');
+      final a = await service.create(
+        accountId: accountId, operationDate: DateTime(2024, 1, 1),
+        amount: 100.0, currency: 'EUR',
+      );
+      final b = await service.create(
+        accountId: accountId, operationDate: DateTime(2024, 1, 2),
+        amount: 200.0, currency: 'EUR',
+      );
+      final c = await service.create(
+        accountId: accountId, operationDate: DateTime(2024, 1, 3),
+        amount: 300.0, currency: 'EUR',
+      );
+
+      expect(await service.deleteMany([a, c]), 2);
+
+      final remaining = await service.getByAccount(accountId);
+      expect(remaining.map((t) => t.id), [b]);
+    });
   });
 
   group('batchUpdateBalances', () {

--- a/test/ui/selection_controller_test.dart
+++ b/test/ui/selection_controller_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:finance_copilot/ui/widgets/selection/selection_controller.dart';
+
+void main() {
+  group('SelectionController', () {
+    test('starts inactive and empty', () {
+      final c = SelectionController<int>();
+      expect(c.active, isFalse);
+      expect(c.count, 0);
+      expect(c.ids, isEmpty);
+      expect(c.contains(1), isFalse);
+    });
+
+    test('enter activates selection and notifies listeners', () {
+      final c = SelectionController<int>();
+      var notifications = 0;
+      c.addListener(() => notifications++);
+
+      c.enter(1);
+
+      expect(c.active, isTrue);
+      expect(c.count, 1);
+      expect(c.contains(1), isTrue);
+      expect(notifications, 1);
+    });
+
+    test('enter is idempotent for the same id', () {
+      final c = SelectionController<int>();
+      var notifications = 0;
+      c.addListener(() => notifications++);
+
+      c.enter(1);
+      c.enter(1);
+
+      expect(c.count, 1);
+      expect(notifications, 1, reason: 'second enter should not notify');
+    });
+
+    test('toggle adds when absent and removes when present', () {
+      final c = SelectionController<int>();
+      c.enter(1);
+      c.toggle(2);
+      expect(c.ids, {1, 2});
+
+      c.toggle(1);
+      expect(c.ids, {2});
+      expect(c.active, isTrue);
+    });
+
+    test('toggle down to empty leaves selection inactive', () {
+      final c = SelectionController<int>();
+      c.enter(1);
+      c.toggle(1);
+      expect(c.active, isFalse);
+      expect(c.count, 0);
+    });
+
+    test('clear empties the selection and notifies exactly once', () {
+      final c = SelectionController<int>();
+      c.enter(1);
+      c.enter(2);
+
+      var notifications = 0;
+      c.addListener(() => notifications++);
+
+      c.clear();
+
+      expect(c.active, isFalse);
+      expect(notifications, 1);
+    });
+
+    test('clear is a no-op when already empty', () {
+      final c = SelectionController<int>();
+      var notifications = 0;
+      c.addListener(() => notifications++);
+
+      c.clear();
+
+      expect(notifications, 0);
+    });
+
+    test('selectAll replaces current selection', () {
+      final c = SelectionController<int>();
+      c.enter(99);
+      c.selectAll([1, 2, 3]);
+      expect(c.ids, {1, 2, 3});
+    });
+
+    test('ids returns an unmodifiable view', () {
+      final c = SelectionController<int>();
+      c.enter(1);
+      expect(() => c.ids.add(42), throwsUnsupportedError);
+    });
+  });
+
+  group('SelectionController range-select on long-press', () {
+    // Build an ordered list of 100 ids 1..100 for the scenarios below.
+    final visible = [for (var i = 1; i <= 100; i++) i];
+
+    test('first long-press with no selection adds only the pressed id', () {
+      final c = SelectionController<int>()..setOrderedIds(visible);
+      c.enter(50);
+      expect(c.ids, {50});
+    });
+
+    test('long-press below existing selection extends down to pressed', () {
+      // Matches the user example: selected 54,57,80,81, long-press 82 -> 54..82.
+      final c = SelectionController<int>()..setOrderedIds(visible);
+      c.enter(54);
+      c.enter(57);
+      c.enter(80);
+      c.enter(81);
+      // At this point, 57/80/81 are not adjacent to anything already selected,
+      // so enter() just added them (covered by the other tests).
+      // Reset and seed a contiguous-free state:
+      c.clear();
+      c.selectAll([54, 57, 80, 81]);
+      c.setOrderedIds(visible);
+
+      c.enter(82);
+
+      expect(c.ids, {for (var i = 54; i <= 82; i++) i});
+    });
+
+    test('long-press above existing selection extends up to pressed', () {
+      // User example: selected 54,57,80,81, long-press 31 -> 31..81.
+      final c = SelectionController<int>();
+      c.selectAll([54, 57, 80, 81]);
+      c.setOrderedIds(visible);
+
+      c.enter(31);
+
+      expect(c.ids, {for (var i = 31; i <= 81; i++) i});
+    });
+
+    test('range selection picks the FURTHEST selected item, not the nearest', () {
+      // Selected 10 and 90, long-press 80. Nearest is 90 (dist 10), furthest
+      // is 10 (dist 70), so the range should be 10..80.
+      final c = SelectionController<int>();
+      c.selectAll([10, 90]);
+      c.setOrderedIds(visible);
+
+      c.enter(80);
+
+      expect(c.ids, {for (var i = 10; i <= 80; i++) i}..add(90));
+    });
+
+    test('long-press on an already-selected id still expands the range', () {
+      // Selected 54,57,80,81, long-press 57. Furthest is 81 (dist 24), so
+      // the range is 57..81. 54 stays isolated, everything from 57..81 set.
+      final c = SelectionController<int>();
+      c.selectAll([54, 57, 80, 81]);
+      c.setOrderedIds(visible);
+
+      c.enter(57);
+
+      expect(c.contains(54), isTrue);
+      for (var i = 57; i <= 81; i++) {
+        expect(c.contains(i), isTrue, reason: '$i should be selected');
+      }
+      expect(c.contains(56), isFalse);
+    });
+
+    test('range select works without ordered ids (fallback to plain add)', () {
+      final c = SelectionController<int>();
+      c.selectAll([1, 2]);
+      // No setOrderedIds() call.
+
+      c.enter(99);
+
+      // Fallback: just added the new id.
+      expect(c.ids, {1, 2, 99});
+    });
+
+    test('range select is a no-op when the pressed id is unknown', () {
+      final c = SelectionController<int>()..setOrderedIds(visible);
+      c.selectAll([10, 20]);
+
+      c.enter(999); // not in the visible list
+
+      // Fallback: just added the new id.
+      expect(c.ids, {10, 20, 999});
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Two related UX improvements across the list screens:

**1. Drag-and-drop → 3-dots menu** (commit 222b86f)
- Removes the long-press-drag gesture for reassigning an asset/account to an intermediary.
- Every row now has a trailing `more_vert` button that opens a popup listing all intermediaries plus "Unassigned" (with a checkmark on the current one).
- Drops the redundant per-header edit/delete intermediary popup — the floating business-icon button already owns that flow.

**2. Long-press multi-select + bulk delete** (commit eb4cc99)
- Three reusable primitives under `lib/ui/widgets/selection/`:
  - `SelectionController<T>` — generic `ChangeNotifier` tracking selected ids, including range-expansion on long-press while active.
  - `SelectableItem<T>` — thin gesture + overlay wrapper; the existing tile is rendered verbatim so no screen theming changes.
  - `SelectionActionBar<T>` — persistent bottom bar with count, Select all / Deselect all, and a red Delete that opens a confirmation dialog.
- Wired into all six list screens: Assets, Accounts, Asset events (asset detail), Transactions (account detail), Incomes, Capex (both Spread and Income Adjustments tabs).
- Each screen adds about a dozen lines: a controller field, a `ListenableBuilder` around the Scaffold, `SelectableItem` wrappers, and the conditional `bottomNavigationBar` / FAB swap.
- **Range-select shortcut**: when selection is already active, long-pressing another row extends the selection from that row to the *furthest* already-selected row (by index distance), inclusive. Matches the user request: selected `54, 57, 80, 81` + long-press `82` → `54..82`; long-press `31` → `31..81`.
- New `deleteMany(List<int> ids)` on 7 services (AssetService, AccountService, AssetEventService, TransactionService, IncomeService, CapexService, IncomeAdjustmentService) with cascade handling for Assets (events/snapshots/prices), Accounts (transactions/import configs), Capex (buffer/entries) and IncomeAdjustment (expenses).
- No code duplication: the confirmation dialog, count formatting, select-all toggling and delete wiring all live in `SelectionActionBar`.

## Test plan
- [x] `dart analyze lib/ test/ integration_test/` — zero issues
- [x] `flutter test` — 426/426 (395 baseline + 16 SelectionController + 15 deleteMany)
- [x] `flutter test integration_test/all_tests.dart -d macos` — 34/34
- [x] `flutter test integration_test/live_data_fetch_test.dart -d macos` — green
- [x] macOS release build + manual smoke test on all six screens (range-select confirmed working)
- [ ] Windows / Android release builds (CI)