### PR TITLE
Add CSV import preview with balance/quantity predictions

### DIFF
--- a/lib/l10n/app_strings.dart
+++ b/lib/l10n/app_strings.dart
@@ -674,6 +674,19 @@ class AppStrings {
   String get importAnother         => _it ? 'Importa un altro'         : 'Import Another';
   String get done                  => _it ? 'Fatto'                    : 'Done';
 
+  // ── Import Preview ──────────────────────────────────────
+  String get importPreviewTitle    => _it ? 'Anteprima importazione'   : 'Import Preview';
+  String get predictedBalance      => _it ? 'Saldo previsto'           : 'Predicted balance';
+  String get importAmountSum       => _it ? 'Somma importi'            : 'Import amount sum';
+  String get rowsToReplace         => _it ? 'Righe da sostituire'      : 'Rows to replace';
+  String get parsedRowsLabel       => _it ? 'Righe analizzate'         : 'Parsed rows';
+  String get computingPreview      => _it ? 'Calcolo anteprima...'     : 'Computing preview...';
+  String get netQuantity           => _it ? 'Qtà netta'                : 'Net qty';
+  String get buysLabel             => _it ? 'Acquisti'                 : 'Buys';
+  String get sellsLabel            => _it ? 'Vendite'                  : 'Sells';
+  String get assetLabel            => _it ? 'Attività'                 : 'Asset';
+  String get previewError          => _it ? 'Errore anteprima'         : 'Preview error';
+
   // ── Column Mapper ───────────────────────────────────────
   String get modeLabel             => _it ? 'Modalità: '               : 'Mode: ';
   String get modeHistoric          => _it ? 'Storico'                  : 'Historic';

--- a/lib/services/import_service.dart
+++ b/lib/services/import_service.dart
@@ -97,6 +97,59 @@ class AssetImportResult {
   const AssetImportResult({required this.result, required this.assetsByIsin});
 }
 
+/// Preview of a transaction import (dry run, no DB writes).
+class TransactionImportPreview {
+  final int parsedRows;
+  final int errorRows;
+  final List<String> errors;
+  final double importSum;
+  final double? predictedBalance;
+  final int rowsToReplace;
+
+  const TransactionImportPreview({
+    required this.parsedRows,
+    required this.errorRows,
+    this.errors = const [],
+    required this.importSum,
+    this.predictedBalance,
+    required this.rowsToReplace,
+  });
+}
+
+/// Summary of a single asset in an asset event import preview.
+class AssetPreviewSummary {
+  final String isin;
+  final String? name;
+  final int buyCount;
+  final int sellCount;
+  final double netQuantity;
+  final String? currency;
+
+  const AssetPreviewSummary({
+    required this.isin,
+    this.name,
+    required this.buyCount,
+    required this.sellCount,
+    required this.netQuantity,
+    this.currency,
+  });
+}
+
+/// Preview of an asset event import (dry run, no DB writes).
+class AssetEventImportPreview {
+  final int parsedRows;
+  final int errorRows;
+  final List<String> errors;
+  final Map<String, AssetPreviewSummary> assetSummary;
+
+  const AssetEventImportPreview({
+    required this.parsedRows,
+    required this.errorRows,
+    this.errors = const [],
+    required this.assetSummary,
+  });
+}
+
 /// Generic file importer: applies user column mapping, hashes rows for dedup,
 /// and inserts. File parsing is delegated to [FileParserService].
 class ImportService {
@@ -775,9 +828,262 @@ class ImportService {
   }
 
   // ──────────────────────────────────────────────
-  // Helpers
+  // Preview (dry-run) methods
   // ──────────────────────────────────────────────
 
+  /// Dry-run a transaction import: parse all rows, compute predicted balance,
+  /// and count rows that would be replaced — without touching the DB.
+  Future<TransactionImportPreview> previewTransactionImport({
+    required FilePreview preview,
+    required List<ColumnMapping> mappings,
+    required int accountId,
+    String balanceMode = 'cumulative',
+    String? balanceFilterColumn,
+    Set<String>? balanceFilterInclude,
+  }) async {
+    _log.info('previewTransactionImport: accountId=$accountId, ${preview.totalRows} rows');
+    final mappingByField = {for (final m in mappings) m.targetField: m};
+    final dateMapping = mappingByField['date'];
+    final amountMapping = mappingByField['amount'];
+
+    if (dateMapping == null || amountMapping == null) {
+      return const TransactionImportPreview(
+        parsedRows: 0, errorRows: 0, importSum: 0, rowsToReplace: 0,
+        errors: ['date and amount columns are required'],
+      );
+    }
+
+    // Pre-compute balance-diff amounts if needed
+    List<double>? balanceDiffAmounts;
+    if (amountMapping.isBalanceDiff) {
+      final balCol = amountMapping.balanceDiffColumn!;
+      balanceDiffAmounts = [];
+      double? prevBalance;
+      for (final row in preview.rows) {
+        final raw = row[balCol] ?? '';
+        final balance = _tryParseAmount(raw);
+        if (balance != null && prevBalance != null) {
+          balanceDiffAmounts.add(balance - prevBalance);
+        } else {
+          balanceDiffAmounts.add(balance ?? 0);
+        }
+        prevBalance = balance;
+      }
+    }
+
+    final statusMapping = mappingByField['status'];
+    final valueDateMapping = mappingByField['valueDate'];
+
+    var parsed = 0;
+    var errorCount = 0;
+    final errors = <String>[];
+    double importSum = 0;
+    DateTime? oldestDate;
+
+    for (var i = 0; i < preview.rows.length; i++) {
+      final row = preview.rows[i];
+      try {
+        final dateStr = _resolveMapping(dateMapping, row) ?? '';
+        final double amount;
+        if (balanceDiffAmounts != null) {
+          amount = balanceDiffAmounts[i];
+        } else {
+          final amountStr = _resolveMapping(amountMapping, row) ?? '';
+          amount = _parseAmount(amountStr);
+        }
+
+        // Parse value date (for fallback only)
+        DateTime? valueDate;
+        if (valueDateMapping != null) {
+          final vdStr = _resolveMapping(valueDateMapping, row);
+          if (vdStr != null && vdStr.isNotEmpty) {
+            try { valueDate = _parseDate(vdStr); } catch (_) {}
+          }
+        }
+
+        DateTime date;
+        try {
+          date = _parseDate(dateStr);
+        } catch (_) {
+          if (valueDate != null) {
+            date = valueDate;
+          } else {
+            rethrow;
+          }
+        }
+
+        // Check filtered mode
+        if (balanceMode == 'filtered' && balanceFilterColumn != null) {
+          final filterVal = (row[balanceFilterColumn] ?? '').trim();
+          final included = balanceFilterInclude == null ||
+              balanceFilterInclude.isEmpty ||
+              balanceFilterInclude.contains(filterVal);
+          if (included) importSum += amount;
+        } else {
+          importSum += amount;
+        }
+
+        if (oldestDate == null || date.isBefore(oldestDate)) oldestDate = date;
+        parsed++;
+      } catch (e) {
+        errorCount++;
+        if (errors.length < 5) errors.add('Line ${i + 1}: $e');
+      }
+    }
+
+    // Count rows that would be deleted (replaced)
+    var rowsToReplace = 0;
+    double? predictedBalance;
+    if (oldestDate != null) {
+      final cutoffEpoch = DateTime(oldestDate.year, oldestDate.month, oldestDate.day)
+          .millisecondsSinceEpoch ~/ 1000;
+
+      final countResult = await _db.customSelect(
+        'SELECT COUNT(*) AS cnt FROM transactions WHERE account_id = ? AND operation_date >= ?',
+        variables: [Variable.withInt(accountId), Variable.withInt(cutoffEpoch)],
+      ).getSingle();
+      rowsToReplace = countResult.read<int>('cnt');
+
+      // Predicted balance = balance before cutoff + sum of CSV amounts
+      if (balanceMode == 'column') {
+        // In column mode, the balance comes from the CSV — just show the import sum
+        predictedBalance = null;
+      } else {
+        final balBeforeResult = await _db.customSelect(
+          'SELECT balance_after FROM transactions '
+          'WHERE account_id = ? AND operation_date < ? '
+          'ORDER BY value_date DESC, id DESC LIMIT 1',
+          variables: [Variable.withInt(accountId), Variable.withInt(cutoffEpoch)],
+        ).getSingleOrNull();
+        final balanceBefore = balBeforeResult?.readNullable<double>('balance_after') ?? 0.0;
+        predictedBalance = balanceBefore + importSum;
+      }
+    }
+
+    _log.info('previewTransactionImport: parsed=$parsed, errors=$errorCount, sum=$importSum, '
+        'predicted=$predictedBalance, toReplace=$rowsToReplace');
+    return TransactionImportPreview(
+      parsedRows: parsed,
+      errorRows: errorCount,
+      errors: errors,
+      importSum: importSum,
+      predictedBalance: predictedBalance,
+      rowsToReplace: rowsToReplace,
+    );
+  }
+
+  /// Dry-run an asset event import: parse all rows, compute per-ISIN summaries
+  /// — without touching the DB.
+  Future<AssetEventImportPreview> previewAssetEventImport({
+    required FilePreview preview,
+    required List<ColumnMapping> mappings,
+    Set<String>? buyValues,
+    Set<String>? sellValues,
+    Set<String>? excludedIsins,
+    Map<String, IsinExchangeOption>? selectedExchanges,
+  }) async {
+    _log.info('previewAssetEventImport: ${preview.totalRows} rows');
+    final mappingByField = {for (final m in mappings) m.targetField: m};
+    final isinMapping = mappingByField['isin'];
+
+    if (isinMapping == null) {
+      return const AssetEventImportPreview(
+        parsedRows: 0, errorRows: 0, assetSummary: {},
+        errors: ['ISIN column is required'],
+      );
+    }
+
+    final typeMapping = mappingByField['type'];
+    final qtyMapping = mappingByField['quantity'];
+    final amountMapping = mappingByField['amount'];
+    final currencyMapping = mappingByField['currency'];
+
+    var parsed = 0;
+    var errorCount = 0;
+    final errors = <String>[];
+
+    // Accumulate per-ISIN: buyCount, sellCount, netQty
+    final buyCountByIsin = <String, int>{};
+    final sellCountByIsin = <String, int>{};
+    final netQtyByIsin = <String, double>{};
+    final currencyByIsin = <String, String>{};
+
+    for (var i = 0; i < preview.rows.length; i++) {
+      final row = preview.rows[i];
+      try {
+        final isin = (_resolveMapping(isinMapping, row) ?? '').trim().toUpperCase();
+        if (isin.isEmpty) {
+          errorCount++;
+          if (errors.length < 5) errors.add('Line ${i + 1}: empty ISIN');
+          continue;
+        }
+        if (excludedIsins != null && excludedIsins.contains(isin)) continue;
+
+        final qty = qtyMapping != null ? _tryParseAmount(_resolveMapping(qtyMapping, row)) : null;
+        final amount = amountMapping != null ? _tryParseAmount(_resolveMapping(amountMapping, row)) : null;
+
+        // Determine event type
+        final EventType eventType;
+        if (typeMapping != null) {
+          final typeStr = _resolveMapping(typeMapping, row) ?? 'BUY';
+          eventType = _parseEventType(typeStr, buyValues: buyValues, sellValues: sellValues);
+        } else {
+          final isNeg = (qty != null && qty < 0) || (amount != null && amount < 0);
+          eventType = isNeg ? EventType.sell : EventType.buy;
+        }
+
+        final absQty = qty?.abs() ?? 0;
+        buyCountByIsin[isin] = (buyCountByIsin[isin] ?? 0) + (eventType == EventType.buy ? 1 : 0);
+        sellCountByIsin[isin] = (sellCountByIsin[isin] ?? 0) + (eventType == EventType.sell ? 1 : 0);
+        netQtyByIsin[isin] = (netQtyByIsin[isin] ?? 0) +
+            (eventType == EventType.sell ? -absQty : absQty);
+
+        if (currencyMapping != null && !currencyByIsin.containsKey(isin)) {
+          currencyByIsin[isin] = (_resolveMapping(currencyMapping, row) ?? '').trim();
+        }
+
+        parsed++;
+      } catch (e) {
+        errorCount++;
+        if (errors.length < 5) errors.add('Line ${i + 1}: $e');
+      }
+    }
+
+    // Look up existing asset names for known ISINs
+    final existingNames = <String, String>{};
+    final existingRows = await _db.customSelect(
+      "SELECT isin, name FROM assets WHERE isin IS NOT NULL AND isin != ''",
+      readsFrom: {_db.assets},
+    ).get();
+    for (final row in existingRows) {
+      existingNames[row.read<String>('isin').toUpperCase()] = row.read<String>('name');
+    }
+
+    final summary = <String, AssetPreviewSummary>{};
+    for (final isin in netQtyByIsin.keys) {
+      final name = existingNames[isin] ?? selectedExchanges?[isin]?.name;
+      summary[isin] = AssetPreviewSummary(
+        isin: isin,
+        name: name,
+        buyCount: buyCountByIsin[isin] ?? 0,
+        sellCount: sellCountByIsin[isin] ?? 0,
+        netQuantity: netQtyByIsin[isin] ?? 0,
+        currency: currencyByIsin[isin],
+      );
+    }
+
+    _log.info('previewAssetEventImport: parsed=$parsed, errors=$errorCount, assets=${summary.length}');
+    return AssetEventImportPreview(
+      parsedRows: parsed,
+      errorRows: errorCount,
+      errors: errors,
+      assetSummary: summary,
+    );
+  }
+
+  // ──────────────────────────────────────────────
+  // Helpers
+  // ──────────────────────────────────────────────
 
   /// Parse a date string. Delegates to shared [date_parse.parseDate].
   DateTime _parseDate(String s) => date_parse.parseDate(s);

--- a/lib/ui/screens/import/column_mapper_step.dart
+++ b/lib/ui/screens/import/column_mapper_step.dart
@@ -454,6 +454,7 @@ extension _ColumnMapperStep on _ImportScreenState {
               onPressed: _canProceedToConfirm() ? () {
                 _setState(() => _step = 2);
                 if (_target == ImportTarget.assetEvent) _lookupIsins();
+                _computePreview();
               } : null,
               child: Text(s.next),
             ),

--- a/lib/ui/screens/import/confirm_step.dart
+++ b/lib/ui/screens/import/confirm_step.dart
@@ -338,7 +338,8 @@ extension _ConfirmStep on _ImportScreenState {
 
     if (_target == ImportTarget.assetEvent && _assetPreview != null) {
       final p = _assetPreview!;
-      final entries = p.assetSummary.values.toList()..sort((a, b) => a.isin.compareTo(b.isin));
+      final totalBuys = p.assetSummary.values.fold(0, (sum, e) => sum + e.buyCount);
+      final totalSells = p.assetSummary.values.fold(0, (sum, e) => sum + e.sellCount);
       return Card(
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -349,40 +350,9 @@ extension _ConfirmStep on _ImportScreenState {
               const SizedBox(height: 8),
               _previewRow(s.parsedRowsLabel, '${p.parsedRows}'),
               if (p.errorRows > 0) _previewRow(s.skippedLabel, '${p.errorRows}', color: Colors.red),
-              const SizedBox(height: 8),
-              // Per-asset summary table
-              SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child: DataTable(
-                  headingRowHeight: 32,
-                  dataRowMinHeight: 28,
-                  dataRowMaxHeight: 32,
-                  columnSpacing: 16,
-                  columns: [
-                    DataColumn(label: Text(s.assetLabel, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold))),
-                    DataColumn(label: Text(s.buysLabel, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold)), numeric: true),
-                    DataColumn(label: Text(s.sellsLabel, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold)), numeric: true),
-                    DataColumn(label: Text(s.netQuantity, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold)), numeric: true),
-                  ],
-                  rows: entries.map((e) => DataRow(cells: [
-                    DataCell(Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(e.name ?? e.isin, style: const TextStyle(fontSize: 11), overflow: TextOverflow.ellipsis),
-                        if (e.name != null) Text(e.isin, style: const TextStyle(fontSize: 9, color: Colors.grey)),
-                      ],
-                    )),
-                    DataCell(Text('${e.buyCount}', style: const TextStyle(fontSize: 11))),
-                    DataCell(Text('${e.sellCount}', style: const TextStyle(fontSize: 11))),
-                    DataCell(Text(
-                      fmt.qtyFormat(locale).format(e.netQuantity),
-                      style: TextStyle(fontSize: 11, fontWeight: FontWeight.bold,
-                          color: e.netQuantity >= 0 ? Colors.green : Colors.red),
-                    )),
-                  ])).toList(),
-                ),
-              ),
+              _previewRow(s.assetLabel, '${p.assetSummary.length}'),
+              _previewRow(s.buysLabel, '$totalBuys', color: Colors.green),
+              if (totalSells > 0) _previewRow(s.sellsLabel, '$totalSells', color: Colors.red),
               if (p.errors.isNotEmpty) ...[
                 const SizedBox(height: 4),
                 ...p.errors.take(3).map((e) => Text(e, style: const TextStyle(fontSize: 11, color: Colors.red))),

--- a/lib/ui/screens/import/confirm_step.dart
+++ b/lib/ui/screens/import/confirm_step.dart
@@ -72,140 +72,149 @@ extension _ConfirmStep on _ImportScreenState {
     final isAssetImport = _target == ImportTarget.assetEvent;
     final isIncomeImport = _target == ImportTarget.income;
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (isAssetImport) ...[
-          Text(s.selectIntermediary, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-          const SizedBox(height: 8),
-          _buildIntermediarySelector(),
-          const SizedBox(height: 24),
-        ],
-
-        // Summary
-        Card(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
+        // Scrollable content area
+        Expanded(
+          child: SingleChildScrollView(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(s.importSummary, style: const TextStyle(fontWeight: FontWeight.bold)),
-                const SizedBox(height: 8),
-                Text(s.sourceFile(_filePath?.split('/').last ?? s.clipboard)),
-                Text(s.rowCount(_preview?.totalRows ?? 0)),
-                Text('Target: ${isAssetImport ? s.targetAssetEvents : isIncomeImport ? s.importTypeIncome : s.targetTransactions}'),
-                const SizedBox(height: 8),
-                Text(s.mappingsLabel, style: const TextStyle(fontWeight: FontWeight.bold)),
-                ..._mappings.entries
-                    .where((e) => e.value != null && !(e.key == 'amount' && _amountFormula.isNotEmpty))
-                    .map((e) => Text('  ${e.key} ← ${e.value}')),
-                if (_amountFormula.isNotEmpty)
-                  Text('  amount ← ${_amountFormula.map((t) => '${t.operator} ${t.sourceColumn}').join(' ').replaceFirst('+ ', '')}'),
                 if (isAssetImport) ...[
-                  const SizedBox(height: 12),
-                  Text(s.assetsAndExchange, style: const TextStyle(fontWeight: FontWeight.bold)),
-                  const SizedBox(height: 4),
-                  if (_lookingUpIsins)
-                    Padding(
-                      padding: const EdgeInsets.all(8),
-                      child: Row(children: [
-                        const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)),
-                        const SizedBox(width: 8),
-                        Text(s.lookingUpExchanges, style: const TextStyle(fontSize: 12, color: Colors.grey)),
-                      ]),
-                    )
-                  else ...[
-                    // Default exchange selector
-                    if (_isinLookupResults != null) ...[
-                      Row(
-                        children: [
-                          Text(s.defaultExchange, style: const TextStyle(fontSize: 12)),
-                          const SizedBox(width: 4),
-                          DropdownButton<String>(
-                            value: _defaultExchange,
-                            hint: Text(s.auto, style: const TextStyle(fontSize: 12)),
-                            isDense: true,
-                            items: _allExchanges().map((ex) => DropdownMenuItem(value: ex, child: Text(ex, style: const TextStyle(fontSize: 12)))).toList(),
-                            onChanged: (v) => _setState(() {
-                              _defaultExchange = v;
-                              // Re-apply default to all ISINs
-                              for (final entry in _isinLookupResults!.entries) {
-                                final best = entry.value.bestFor(v);
-                                if (best != null) _selectedExchanges[entry.key] = best;
-                              }
-                            }),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 4),
-                    ],
-                    // Per-ISIN exchange picker with exclude checkbox
-                    ..._getIsinSummary().entries.map((e) {
-                      final isin = e.key;
-                      final count = e.value;
-                      final options = _isinLookupResults?[isin]?.options ?? [];
-                      final selected = _selectedExchanges[isin];
-                      final excluded = _excludedIsins.contains(isin);
-                      return Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 2),
-                        child: Row(
-                          children: [
-                            SizedBox(
-                              width: 24, height: 24,
-                              child: Checkbox(
-                                value: !excluded,
-                                onChanged: (v) => _setState(() {
-                                  if (v == true) {
-                                    _excludedIsins.remove(isin);
-                                  } else {
-                                    _excludedIsins.add(isin);
-                                  }
-                                }),
-                                visualDensity: VisualDensity.compact,
-                                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  Text(s.selectIntermediary, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 8),
+                  _buildIntermediarySelector(),
+                  const SizedBox(height: 24),
+                ],
+
+                // Summary
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(s.importSummary, style: const TextStyle(fontWeight: FontWeight.bold)),
+                        const SizedBox(height: 8),
+                        Text(s.sourceFile(_filePath?.split('/').last ?? s.clipboard)),
+                        Text(s.rowCount(_preview?.totalRows ?? 0)),
+                        Text('Target: ${isAssetImport ? s.targetAssetEvents : isIncomeImport ? s.importTypeIncome : s.targetTransactions}'),
+                        const SizedBox(height: 8),
+                        Text(s.mappingsLabel, style: const TextStyle(fontWeight: FontWeight.bold)),
+                        ..._mappings.entries
+                            .where((e) => e.value != null && !(e.key == 'amount' && _amountFormula.isNotEmpty))
+                            .map((e) => Text('  ${e.key} ← ${e.value}')),
+                        if (_amountFormula.isNotEmpty)
+                          Text('  amount ← ${_amountFormula.map((t) => '${t.operator} ${t.sourceColumn}').join(' ').replaceFirst('+ ', '')}'),
+                        if (isAssetImport) ...[
+                          const SizedBox(height: 12),
+                          Text(s.assetsAndExchange, style: const TextStyle(fontWeight: FontWeight.bold)),
+                          const SizedBox(height: 4),
+                          if (_lookingUpIsins)
+                            Padding(
+                              padding: const EdgeInsets.all(8),
+                              child: Row(children: [
+                                const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)),
+                                const SizedBox(width: 8),
+                                Text(s.lookingUpExchanges, style: const TextStyle(fontSize: 12, color: Colors.grey)),
+                              ]),
+                            )
+                          else ...[
+                            // Default exchange selector
+                            if (_isinLookupResults != null) ...[
+                              Row(
+                                children: [
+                                  Text(s.defaultExchange, style: const TextStyle(fontSize: 12)),
+                                  const SizedBox(width: 4),
+                                  DropdownButton<String>(
+                                    value: _defaultExchange,
+                                    hint: Text(s.auto, style: const TextStyle(fontSize: 12)),
+                                    isDense: true,
+                                    items: _allExchanges().map((ex) => DropdownMenuItem(value: ex, child: Text(ex, style: const TextStyle(fontSize: 12)))).toList(),
+                                    onChanged: (v) => _setState(() {
+                                      _defaultExchange = v;
+                                      // Re-apply default to all ISINs
+                                      for (final entry in _isinLookupResults!.entries) {
+                                        final best = entry.value.bestFor(v);
+                                        if (best != null) _selectedExchanges[entry.key] = best;
+                                      }
+                                    }),
+                                  ),
+                                ],
                               ),
-                            ),
-                            const SizedBox(width: 4),
-                            SizedBox(width: 130, child: Text(isin, style: TextStyle(fontSize: 12, fontFamily: 'monospace', color: excluded ? Colors.grey : null))),
-                            const SizedBox(width: 4),
-                            Text(s.nEventsCount(count), style: const TextStyle(fontSize: 11, color: Colors.grey)),
-                            const SizedBox(width: 8),
-                            if (options.length > 1)
-                              Expanded(
-                                child: DropdownButton<int>(
-                                  value: selected?.cid,
-                                  isDense: true,
-                                  isExpanded: true,
-                                  items: options.map((o) => DropdownMenuItem(
-                                    value: o.cid,
-                                    child: Text('${o.ticker} — ${o.exchange}', style: const TextStyle(fontSize: 12)),
-                                  )).toList(),
-                                  onChanged: excluded ? null : (cid) => _setState(() {
-                                    _selectedExchanges[isin] = options.firstWhere((o) => o.cid == cid);
-                                  }),
+                              const SizedBox(height: 4),
+                            ],
+                            // Per-ISIN exchange picker with exclude checkbox
+                            ..._getIsinSummary().entries.map((e) {
+                              final isin = e.key;
+                              final count = e.value;
+                              final options = _isinLookupResults?[isin]?.options ?? [];
+                              final selected = _selectedExchanges[isin];
+                              final excluded = _excludedIsins.contains(isin);
+                              return Padding(
+                                padding: const EdgeInsets.symmetric(vertical: 2),
+                                child: Row(
+                                  children: [
+                                    SizedBox(
+                                      width: 24, height: 24,
+                                      child: Checkbox(
+                                        value: !excluded,
+                                        onChanged: (v) => _setState(() {
+                                          if (v == true) {
+                                            _excludedIsins.remove(isin);
+                                          } else {
+                                            _excludedIsins.add(isin);
+                                          }
+                                        }),
+                                        visualDensity: VisualDensity.compact,
+                                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                                      ),
+                                    ),
+                                    const SizedBox(width: 4),
+                                    SizedBox(width: 130, child: Text(isin, style: TextStyle(fontSize: 12, fontFamily: 'monospace', color: excluded ? Colors.grey : null))),
+                                    const SizedBox(width: 4),
+                                    Text(s.nEventsCount(count), style: const TextStyle(fontSize: 11, color: Colors.grey)),
+                                    const SizedBox(width: 8),
+                                    if (options.length > 1)
+                                      Expanded(
+                                        child: DropdownButton<int>(
+                                          value: selected?.cid,
+                                          isDense: true,
+                                          isExpanded: true,
+                                          items: options.map((o) => DropdownMenuItem(
+                                            value: o.cid,
+                                            child: Text('${o.ticker} — ${o.exchange}', style: const TextStyle(fontSize: 12)),
+                                          )).toList(),
+                                          onChanged: excluded ? null : (cid) => _setState(() {
+                                            _selectedExchanges[isin] = options.firstWhere((o) => o.cid == cid);
+                                          }),
+                                        ),
+                                      )
+                                    else if (options.length == 1)
+                                      Expanded(child: Text('${options.first.ticker} — ${options.first.exchange}', style: TextStyle(fontSize: 12, color: excluded ? Colors.grey : null)))
+                                    else
+                                      Expanded(child: Text(s.notFound, style: const TextStyle(fontSize: 12, color: Colors.grey))),
+                                  ],
                                 ),
-                              )
-                            else if (options.length == 1)
-                              Expanded(child: Text('${options.first.ticker} — ${options.first.exchange}', style: TextStyle(fontSize: 12, color: excluded ? Colors.grey : null)))
-                            else
-                              Expanded(child: Text(s.notFound, style: const TextStyle(fontSize: 12, color: Colors.grey))),
+                              );
+                            }),
                           ],
-                        ),
-                      );
-                    }),
-                  ],
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+
+                // ── Import Preview ──────────────────────────────
+                if (!isIncomeImport) ...[
+                  const SizedBox(height: 16),
+                  _buildImportPreview(),
                 ],
               ],
             ),
           ),
         ),
 
-        // ── Import Preview ──────────────────────────────
-        if (!isIncomeImport) ...[
-          const SizedBox(height: 16),
-          _buildImportPreview(),
-        ],
-
-        const Spacer(),
+        // Pinned bottom: error / progress / import button
         if (_error != null)
           Padding(
             padding: const EdgeInsets.only(bottom: 8),

--- a/lib/ui/screens/import/confirm_step.dart
+++ b/lib/ui/screens/import/confirm_step.dart
@@ -199,6 +199,12 @@ extension _ConfirmStep on _ImportScreenState {
           ),
         ),
 
+        // ── Import Preview ──────────────────────────────
+        if (!isIncomeImport) ...[
+          const SizedBox(height: 16),
+          _buildImportPreview(),
+        ],
+
         const Spacer(),
         if (_error != null)
           Padding(
@@ -276,6 +282,123 @@ extension _ConfirmStep on _ImportScreenState {
     );
   }
 
+  Widget _buildImportPreview() {
+    final s = ref.watch(appStringsProvider);
+    final locale = ref.watch(appLocaleProvider).value ?? Platform.localeName;
+    final amtFmt = fmt.amountFormat(locale);
+
+    if (_previewing) {
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(children: [
+            const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)),
+            const SizedBox(width: 12),
+            Text(s.computingPreview, style: const TextStyle(fontSize: 13, color: Colors.grey)),
+          ]),
+        ),
+      );
+    }
+
+    if (_target == ImportTarget.transaction && _txPreview != null) {
+      final p = _txPreview!;
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(s.importPreviewTitle, style: const TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              _previewRow(s.parsedRowsLabel, '${p.parsedRows}'),
+              if (p.errorRows > 0) _previewRow(s.skippedLabel, '${p.errorRows}', color: Colors.red),
+              if (p.rowsToReplace > 0) _previewRow(s.rowsToReplace, '${p.rowsToReplace}', color: Colors.orange),
+              _previewRow(s.importAmountSum, amtFmt.format(p.importSum)),
+              if (p.predictedBalance != null)
+                _previewRow(s.predictedBalance, amtFmt.format(p.predictedBalance!),
+                    color: Theme.of(context).colorScheme.primary, bold: true),
+              if (p.errors.isNotEmpty) ...[
+                const SizedBox(height: 4),
+                ...p.errors.take(3).map((e) => Text(e, style: const TextStyle(fontSize: 11, color: Colors.red))),
+              ],
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_target == ImportTarget.assetEvent && _assetPreview != null) {
+      final p = _assetPreview!;
+      final entries = p.assetSummary.values.toList()..sort((a, b) => a.isin.compareTo(b.isin));
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(s.importPreviewTitle, style: const TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              _previewRow(s.parsedRowsLabel, '${p.parsedRows}'),
+              if (p.errorRows > 0) _previewRow(s.skippedLabel, '${p.errorRows}', color: Colors.red),
+              const SizedBox(height: 8),
+              // Per-asset summary table
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: DataTable(
+                  headingRowHeight: 32,
+                  dataRowMinHeight: 28,
+                  dataRowMaxHeight: 32,
+                  columnSpacing: 16,
+                  columns: [
+                    DataColumn(label: Text(s.assetLabel, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold))),
+                    DataColumn(label: Text(s.buysLabel, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold)), numeric: true),
+                    DataColumn(label: Text(s.sellsLabel, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold)), numeric: true),
+                    DataColumn(label: Text(s.netQuantity, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold)), numeric: true),
+                  ],
+                  rows: entries.map((e) => DataRow(cells: [
+                    DataCell(Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(e.name ?? e.isin, style: const TextStyle(fontSize: 11), overflow: TextOverflow.ellipsis),
+                        if (e.name != null) Text(e.isin, style: const TextStyle(fontSize: 9, color: Colors.grey)),
+                      ],
+                    )),
+                    DataCell(Text('${e.buyCount}', style: const TextStyle(fontSize: 11))),
+                    DataCell(Text('${e.sellCount}', style: const TextStyle(fontSize: 11))),
+                    DataCell(Text(
+                      fmt.qtyFormat(locale).format(e.netQuantity),
+                      style: TextStyle(fontSize: 11, fontWeight: FontWeight.bold,
+                          color: e.netQuantity >= 0 ? Colors.green : Colors.red),
+                    )),
+                  ])).toList(),
+                ),
+              ),
+              if (p.errors.isNotEmpty) ...[
+                const SizedBox(height: 4),
+                ...p.errors.take(3).map((e) => Text(e, style: const TextStyle(fontSize: 11, color: Colors.red))),
+              ],
+            ],
+          ),
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  Widget _previewRow(String label, String value, {Color? color, bool bold = false}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          SizedBox(width: 180, child: Text(label, style: const TextStyle(fontSize: 12))),
+          Text(value, style: TextStyle(fontSize: 12, fontWeight: bold ? FontWeight.bold : null, color: color)),
+        ],
+      ),
+    );
+  }
+
   Future<void> _showCreateAccountDialog() async {
     final s = ref.read(appStringsProvider);
     final nameCtrl = TextEditingController();
@@ -319,34 +442,7 @@ extension _ConfirmStep on _ImportScreenState {
 
     try {
       final importer = ref.read(importServiceProvider);
-      final mappings = <ColumnMapping>[];
-      for (final e in _mappings.entries) {
-        if (e.value == null) continue;
-        if (e.key == 'amount' && (_amountFormula.isNotEmpty || _balanceDiffColumn != null)) continue;
-        mappings.add(ColumnMapping(sourceColumn: e.value!, targetField: e.key));
-      }
-      // If settlement date = operation date, copy the date mapping
-      if (_sameSettlementDate && _mappings['date'] != null) {
-        mappings.removeWhere((m) => m.targetField == 'valueDate');
-        mappings.add(ColumnMapping(sourceColumn: _mappings['date']!, targetField: 'valueDate'));
-      }
-      // Multi-column mappings (override single mappings for same field)
-      for (final e in _multiMappings.entries) {
-        if (e.value.length < 2) continue;
-        mappings.removeWhere((m) => m.targetField == e.key);
-        mappings.add(ColumnMapping(targetField: e.key, multiColumns: List.of(e.value), multiDelimiter: _multiDelimiters[e.key] ?? ' '));
-      }
-      // Amount: balance-diff, formula, or simple mapping
-      if (_balanceDiffColumn != null) {
-        _log.info('_executeImport: amount from balance-diff column=$_balanceDiffColumn');
-        mappings.add(ColumnMapping(targetField: 'amount', balanceDiffColumn: _balanceDiffColumn));
-      } else if (_amountFormula.isNotEmpty) {
-        final formulaDesc = _amountFormula.map((t) => '${t.operator}${t.sourceColumn}').join(' ');
-        _log.info('_executeImport: amount formula=$formulaDesc');
-        mappings.add(ColumnMapping(targetField: 'amount', formulaTerms: List.of(_amountFormula)));
-      } else if (_mappings['amount'] != null) {
-        mappings.add(ColumnMapping(sourceColumn: _mappings['amount']!, targetField: 'amount'));
-      }
+      final mappings = _buildColumnMappings();
 
       _log.info('_executeImport: ${mappings.length} column mappings built');
 

--- a/lib/ui/screens/import/import_screen.dart
+++ b/lib/ui/screens/import/import_screen.dart
@@ -14,6 +14,7 @@ import '../../../services/import_service.dart';
 import '../../../services/isin_lookup_service.dart';
 import '../../../l10n/app_strings.dart';
 import '../../../services/providers/providers.dart';
+import '../../../utils/formatters.dart' as fmt;
 import '../../../utils/logger.dart';
 
 part 'column_mapper_step.dart';
@@ -113,6 +114,11 @@ class _ImportScreenState extends ConsumerState<ImportScreen> {
   int _importedSoFar = 0;
   int _importTotal = 0;
   String? _error;
+
+  // Preview (dry-run) state
+  TransactionImportPreview? _txPreview;
+  AssetEventImportPreview? _assetPreview;
+  bool _previewing = false;
 
   List<String> get _requiredFields => switch (_target) {
     ImportTarget.transaction => ['date', 'valueDate', 'amount', 'description'],
@@ -715,5 +721,86 @@ class _ImportScreenState extends ConsumerState<ImportScreen> {
     _isinLookupResults = null;
     _selectedExchanges.clear();
     _defaultExchange = null;
+    _txPreview = null;
+    _assetPreview = null;
+    _previewing = false;
+  }
+
+  /// Build column mappings from current UI state. Shared by preview and import.
+  List<ColumnMapping> _buildColumnMappings() {
+    final mappings = <ColumnMapping>[];
+    for (final e in _mappings.entries) {
+      if (e.value == null) continue;
+      if (e.key == 'amount' && (_amountFormula.isNotEmpty || _balanceDiffColumn != null)) continue;
+      mappings.add(ColumnMapping(sourceColumn: e.value!, targetField: e.key));
+    }
+    if (_sameSettlementDate && _mappings['date'] != null) {
+      mappings.removeWhere((m) => m.targetField == 'valueDate');
+      mappings.add(ColumnMapping(sourceColumn: _mappings['date']!, targetField: 'valueDate'));
+    }
+    for (final e in _multiMappings.entries) {
+      if (e.value.length < 2) continue;
+      mappings.removeWhere((m) => m.targetField == e.key);
+      mappings.add(ColumnMapping(targetField: e.key, multiColumns: List.of(e.value), multiDelimiter: _multiDelimiters[e.key] ?? ' '));
+    }
+    if (_balanceDiffColumn != null) {
+      mappings.add(ColumnMapping(targetField: 'amount', balanceDiffColumn: _balanceDiffColumn));
+    } else if (_amountFormula.isNotEmpty) {
+      mappings.add(ColumnMapping(targetField: 'amount', formulaTerms: List.of(_amountFormula)));
+    } else if (_mappings['amount'] != null) {
+      mappings.add(ColumnMapping(sourceColumn: _mappings['amount']!, targetField: 'amount'));
+    }
+    return mappings;
+  }
+
+  /// Compute a dry-run preview of the import (no DB writes).
+  Future<void> _computePreview() async {
+    if (_preview == null) return;
+    _setState(() {
+      _previewing = true;
+      _txPreview = null;
+      _assetPreview = null;
+    });
+
+    try {
+      final importer = ref.read(importServiceProvider);
+      final mappings = _buildColumnMappings();
+
+      // Get full rows if preview was capped
+      var fullPreview = _preview!;
+      if (fullPreview.rows.length < fullPreview.totalRows) {
+        fullPreview = await importer.getFullRows(fullPreview);
+      }
+
+      if (_target == ImportTarget.transaction && _targetId != null) {
+        final result = await importer.previewTransactionImport(
+          preview: fullPreview,
+          mappings: mappings,
+          accountId: _targetId!,
+          balanceMode: _balanceMode,
+          balanceFilterColumn: _balanceFilterColumn,
+          balanceFilterInclude: _balanceFilterInclude.isNotEmpty ? _balanceFilterInclude : null,
+        );
+        if (mounted) _setState(() => _txPreview = result);
+      } else if (_target == ImportTarget.assetEvent) {
+        // Remove type mapping if using sign-based detection
+        if (_typeMode == 'sign') {
+          mappings.removeWhere((m) => m.targetField == 'type');
+        }
+        final result = await importer.previewAssetEventImport(
+          preview: fullPreview,
+          mappings: mappings,
+          buyValues: _buyValues.isNotEmpty ? _buyValues : null,
+          sellValues: _sellValues.isNotEmpty ? _sellValues : null,
+          excludedIsins: _excludedIsins.isNotEmpty ? _excludedIsins : null,
+          selectedExchanges: _selectedExchanges.isNotEmpty ? _selectedExchanges : null,
+        );
+        if (mounted) _setState(() => _assetPreview = result);
+      }
+    } catch (e) {
+      _log.warning('_computePreview: $e');
+    } finally {
+      if (mounted) _setState(() => _previewing = false);
+    }
   }
 }

--- a/lib/ui/screens/import/quick_confirm_step.dart
+++ b/lib/ui/screens/import/quick_confirm_step.dart
@@ -11,6 +11,13 @@ extension _QuickConfirmStep on _ImportScreenState {
 
   Widget _buildQuickConfirm(FilePreview preview) {
     final s = ref.watch(appStringsProvider);
+
+    // Trigger preview computation once when entering quick confirm
+    if (_txPreview == null && _assetPreview == null && !_previewing &&
+        _target != ImportTarget.income) {
+      Future.microtask(() => _computePreview());
+    }
+
     return SingleChildScrollView(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -44,6 +51,11 @@ extension _QuickConfirmStep on _ImportScreenState {
           const SizedBox(height: 16),
 
           Text(s.rowCount(preview.totalRows), style: TextStyle(fontSize: 12, color: Colors.grey.shade600)),
+          const SizedBox(height: 16),
+
+          // Import preview (balance / asset quantities)
+          if (_target != ImportTarget.income)
+            _buildImportPreview(),
           const SizedBox(height: 16),
 
           // Action buttons


### PR DESCRIPTION
Show a dry-run preview on the confirm step before applying the import:
- Transaction imports: predicted balance, import sum, rows to replace
- Asset event imports: per-ISIN table with buy/sell counts and net quantity
- Income imports: unchanged (already sufficient)

Preview runs automatically when entering the confirm step or quick-confirm
mode. Refactored column mapping construction into shared helper method.

https://claude.ai/code/session_01DezEX3RbD9HFHCFWwCvXvN