### PR TITLE
Add asset detail charts: value and price history

### DIFF
--- a/lib/ui/screens/asset_detail_charts_provider.dart
+++ b/lib/ui/screens/asset_detail_charts_provider.dart
@@ -1,0 +1,114 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../database/providers.dart';
+import '../../database/tables.dart';
+import '../../services/providers/providers.dart';
+import 'dashboard/dashboard_screen.dart'
+    show ChartSeries, allSeriesDataProvider;
+
+/// Chart data for a single asset: invested + market value, and raw price.
+class SingleAssetChartData {
+  final DateTime firstDate;
+  final ChartSeries investedSeries;
+  final ChartSeries marketSeries;
+  final ChartSeries priceSeries;
+  final String baseCurrency;
+  final String assetCurrency;
+
+  const SingleAssetChartData({
+    required this.firstDate,
+    required this.investedSeries,
+    required this.marketSeries,
+    required this.priceSeries,
+    required this.baseCurrency,
+    required this.assetCurrency,
+  });
+}
+
+/// Extracts invested + market series for a single asset from the shared
+/// dashboard [allSeriesDataProvider], and adds a raw price series.
+final singleAssetChartDataProvider =
+    FutureProvider.family<SingleAssetChartData?, int>((ref, assetId) async {
+  final allData = await ref.watch(allSeriesDataProvider.future);
+  if (allData == null) return null;
+
+  // Find this asset's invested and market series from the dashboard data
+  final invMatch = allData.assetInvested
+      .where((s) => s.key == 'asset_invested:$assetId');
+  final mktMatch = allData.assetMarket
+      .where((s) => s.key == 'asset_market:$assetId');
+  if (mktMatch.isEmpty) return null;
+
+  final marketSeries = mktMatch.first;
+  final investedSeries = invMatch.isNotEmpty
+      ? invMatch.first
+      : ChartSeries(
+          key: 'asset_invested:$assetId',
+          name: marketSeries.name,
+          color: Colors.orange,
+          spots: const [],
+          isDashed: true,
+        );
+
+  // Look up the asset for currency and instrument type
+  final db = ref.watch(databaseProvider);
+  final asset = await (db.select(db.assets)
+        ..where((a) => a.id.equals(assetId)))
+      .getSingleOrNull();
+  if (asset == null) return null;
+
+  // Build raw price series from market_prices table
+  final marketPriceService = ref.watch(marketPriceServiceProvider);
+  final prices = await marketPriceService.getPriceHistoryBatch([assetId]);
+  final priceList = prices[assetId] ?? [];
+  final bondDiv = asset.instrumentType == InstrumentType.bond ? 100.0 : 1.0;
+
+  // Find the X offset of this asset's first data point so we can shift
+  // all spots to start at x=0 (avoids empty space from global firstDate).
+  final allAssetSpots = [
+    ...investedSeries.spots,
+    ...marketSeries.spots,
+  ];
+  if (allAssetSpots.isEmpty) return null;
+  final xOffset = allAssetSpots.map((s) => s.x).reduce((a, b) => a < b ? a : b);
+
+  List<FlSpot> shift(List<FlSpot> spots) =>
+      spots.map((s) => FlSpot(s.x - xOffset, s.y)).toList();
+
+  // Asset-local firstDate (shifted by xOffset days from global firstDate)
+  final assetFirstDate = allData.firstDate.add(Duration(days: xOffset.toInt()));
+
+  // Build raw price series, also shifted
+  final priceSpots = <FlSpot>[];
+  for (final p in priceList) {
+    final x = p.key.difference(allData.firstDate).inDays.toDouble() - xOffset;
+    if (x >= 0) priceSpots.add(FlSpot(x, p.value / bondDiv));
+  }
+
+  return SingleAssetChartData(
+    firstDate: assetFirstDate,
+    investedSeries: ChartSeries(
+      key: investedSeries.key,
+      name: investedSeries.name,
+      color: Colors.orange,
+      spots: shift(investedSeries.spots),
+      isDashed: true,
+    ),
+    marketSeries: ChartSeries(
+      key: marketSeries.key,
+      name: marketSeries.name,
+      color: Colors.blue,
+      spots: shift(marketSeries.spots),
+    ),
+    priceSeries: ChartSeries(
+      key: 'asset_price:$assetId',
+      name: marketSeries.name,
+      color: Colors.blue,
+      spots: priceSpots,
+    ),
+    baseCurrency: allData.baseCurrency,
+    assetCurrency: asset.currency,
+  );
+});

--- a/lib/ui/screens/asset_detail_screen.dart
+++ b/lib/ui/screens/asset_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:drift/drift.dart' hide Column;
 import 'package:flutter/material.dart';
@@ -12,8 +13,9 @@ import '../../services/market_price_service.dart' show investingExchangeToCode, 
 import '../../services/providers/providers.dart';
 import '../../utils/formatters.dart' as fmt;
 import '../../utils/logger.dart';
+import 'asset_detail_charts_provider.dart';
 import 'asset_event_edit_screen.dart';
-import 'dashboard/dashboard_screen.dart' show currencySymbol;
+import 'dashboard/dashboard_screen.dart' show ChartSeries, DragZoomWrapper, UnifiedChart, currencySymbol;
 import '../widgets/selection/selectable_item.dart';
 import '../widgets/selection/selection_action_bar.dart';
 import '../widgets/selection/selection_controller.dart';
@@ -116,6 +118,8 @@ class _AssetDetailScreenState extends ConsumerState<AssetDetailScreen> {
               ),
             ),
           ),
+          // Asset charts (portfolio history + performance)
+          _AssetChartSection(assetId: asset.id),
           // Composition breakdown
           _CompositionSection(assetId: asset.id),
           // Events header
@@ -309,6 +313,185 @@ class _AssetDetailScreenState extends ConsumerState<AssetDetailScreen> {
       await ref.read(assetServiceProvider).delete(asset.id);
       if (context.mounted) Navigator.pop(context);
     }
+  }
+}
+
+// ──────────────────────────────────────────────
+// Asset chart cards (value + price)
+// ──────────────────────────────────────────────
+
+class _AssetChartSection extends ConsumerWidget {
+  final int assetId;
+  const _AssetChartSection({required this.assetId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final chartDataAsync = ref.watch(singleAssetChartDataProvider(assetId));
+    return chartDataAsync.when(
+      data: (data) {
+        if (data == null) return const SizedBox.shrink();
+        final s = ref.watch(appStringsProvider);
+        final locale = ref.watch(appLocaleProvider).value ?? Platform.localeName;
+        final baseSymbol = currencySymbol(data.baseCurrency);
+        final baseFmt = fmt.currencyFormat(locale, baseSymbol, decimalDigits: 0);
+        final assetSymbol = currencySymbol(data.assetCurrency);
+        final assetFmt = fmt.currencyFormat(locale, assetSymbol);
+        return Column(
+          children: [
+            _AssetChartCard(
+              title: s.colAsset,
+              titleValue: baseFmt.format(data.marketSeries.spots.last.y),
+              series: [data.investedSeries, data.marketSeries],
+              firstDate: data.firstDate,
+              currency: data.baseCurrency,
+            ),
+            _AssetChartCard(
+              title: s.colPrice,
+              titleValue: assetFmt.format(data.priceSeries.spots.last.y),
+              series: [data.priceSeries],
+              firstDate: data.firstDate,
+              currency: data.assetCurrency,
+            ),
+          ],
+        );
+      },
+      loading: () => const SizedBox.shrink(),
+      error: (_, _) => const SizedBox.shrink(),
+    );
+  }
+}
+
+/// Reusable collapsible chart card. Uses show/hide instead of ExpansionTile
+/// children list to avoid animating the chart widget (which causes jank).
+class _AssetChartCard extends ConsumerStatefulWidget {
+  final String title;
+  final String titleValue;
+  final List<ChartSeries> series;
+  final DateTime firstDate;
+  final String currency; // for axis labels
+
+  const _AssetChartCard({
+    required this.title,
+    required this.titleValue,
+    required this.series,
+    required this.firstDate,
+    required this.currency,
+  });
+
+  @override
+  ConsumerState<_AssetChartCard> createState() => _AssetChartCardState();
+}
+
+class _AssetChartCardState extends ConsumerState<_AssetChartCard> {
+  bool _expanded = false;
+  double? _zoomMinX, _zoomMaxX, _zoomMinY, _zoomMaxY;
+
+  void _onZoom(double? minX, double? maxX, double? minY, double? maxY) {
+    setState(() {
+      _zoomMinX = minX;
+      _zoomMaxX = maxX;
+      _zoomMinY = minY;
+      _zoomMaxY = maxY;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final allSpots = widget.series.expand((s) => s.spots).toList();
+    if (allSpots.length < 2) return const SizedBox.shrink();
+
+    final locale = ref.watch(appLocaleProvider).value ?? Platform.localeName;
+    final language = locale.split('_').first;
+    final isPrivate = ref.watch(privacyModeProvider);
+    final s = ref.watch(appStringsProvider);
+    final hasZoom = _zoomMinX != null || _zoomMinY != null;
+
+    // X range from all series
+    final lastX = allSpots.map((s) => s.x).reduce(max);
+
+    // Y range from all series
+    final allY = allSpots.map((s) => s.y).toList();
+    final autoMinY = allY.reduce(min);
+    final autoMaxY = allY.reduce(max);
+    final autoRange = autoMaxY - autoMinY;
+    final effectiveMinY = _zoomMinY ?? (autoRange > 0 ? autoMinY - autoRange * 0.05 : autoMinY - 100);
+    final effectiveMaxY = _zoomMaxY ?? (autoRange > 0 ? autoMaxY + autoRange * 0.05 : autoMaxY + 100);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Column(
+        children: [
+          InkWell(
+            onTap: () => setState(() => _expanded = !_expanded),
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  Expanded(child: Text(widget.title, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14))),
+                  if (isPrivate)
+                    const Text('****', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13))
+                  else
+                    Text(widget.titleValue,
+                        style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+                  const SizedBox(width: 8),
+                  Icon(_expanded ? Icons.expand_less : Icons.expand_more, size: 20),
+                ],
+              ),
+            ),
+          ),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeInOut,
+            alignment: Alignment.topCenter,
+            child: _expanded ? Padding(
+              padding: const EdgeInsets.fromLTRB(8, 0, 8, 12),
+              child: SizedBox(
+                height: 220,
+                child: Stack(
+                  children: [
+                    DragZoomWrapper(
+                      xMin: _zoomMinX ?? 0,
+                      xMax: _zoomMaxX ?? lastX,
+                      yMin: effectiveMinY,
+                      yMax: effectiveMaxY,
+                      firstDate: widget.firstDate,
+                      baseCurrency: widget.currency,
+                      locale: locale,
+                      onZoom: _onZoom,
+                      child: UnifiedChart(
+                        firstDate: widget.firstDate,
+                        visible: widget.series,
+                        totalSpots: widget.series.first.spots,
+                        showTotal: false,
+                        baseCurrency: widget.currency,
+                        locale: locale,
+                        language: language,
+                        zoomMinX: _zoomMinX,
+                        zoomMaxX: _zoomMaxX,
+                        zoomMinY: _zoomMinY,
+                        zoomMaxY: _zoomMaxY,
+                        isPrivate: isPrivate,
+                      ),
+                    ),
+                    if (hasZoom)
+                      Positioned(
+                        top: 4,
+                        right: 4,
+                        child: IconButton(
+                          icon: const Icon(Icons.zoom_out_map, size: 18),
+                          onPressed: () => _onZoom(null, null, null, null),
+                          tooltip: s.resetZoom,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ) : const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/ui/screens/dashboard/cashflow_tab.dart
+++ b/lib/ui/screens/dashboard/cashflow_tab.dart
@@ -5,7 +5,7 @@ part of 'dashboard_screen.dart';
 // ════════════════════════════════════════════════════
 
 class _CashFlowTab extends ConsumerStatefulWidget {
-  final _AllSeriesData allData;
+  final AllSeriesData allData;
   final String locale;
   final String language;
   const _CashFlowTab({required this.allData, required this.locale, required this.language});
@@ -153,10 +153,10 @@ class _CashFlowTabState extends ConsumerState<_CashFlowTab> {
       (
         id: _idSaving,
         chart: _fakeChart(_idSaving, '${s.dashSaving} vs MA'),
-        series: <_Series>[
-          _Series(key: 'cf:saving',    name: s.dashSaving, color: Colors.blue,          spots: savingSpots),
-          _Series(key: 'cf:saving_ma', name: 'MA',         color: Colors.blue.shade200,  spots: savingMA,   isDashed: true),
-          _Series(key: 'cf:diff',      name: 'Diff',       color: Colors.orange,         spots: savingDiff, rightAxis: true),
+        series: <ChartSeries>[
+          ChartSeries(key: 'cf:saving',    name: s.dashSaving, color: Colors.blue,          spots: savingSpots),
+          ChartSeries(key: 'cf:saving_ma', name: 'MA',         color: Colors.blue.shade200,  spots: savingMA,   isDashed: true),
+          ChartSeries(key: 'cf:diff',      name: 'Diff',       color: Colors.orange,         spots: savingDiff, rightAxis: true),
         ],
         ctl: _savingWinCtl,
         onWin: (int w) => setState(() => _savingWindow = w),
@@ -164,10 +164,10 @@ class _CashFlowTabState extends ConsumerState<_CashFlowTab> {
       (
         id: _idSpending,
         chart: _fakeChart(_idSpending, '${s.legendExpenses} vs MA & ${s.dashCash}'),
-        series: <_Series>[
-          _Series(key: 'cf:spending',    name: s.legendExpenses, color: Colors.red,           spots: spendingSpots),
-          _Series(key: 'cf:spending_ma', name: 'MA',             color: Colors.red.shade200,   spots: spendingMA,  isDashed: true),
-          _Series(key: 'cf:cash',        name: s.dashCash,       color: Colors.green,          spots: cashSpots,   rightAxis: true),
+        series: <ChartSeries>[
+          ChartSeries(key: 'cf:spending',    name: s.legendExpenses, color: Colors.red,           spots: spendingSpots),
+          ChartSeries(key: 'cf:spending_ma', name: 'MA',             color: Colors.red.shade200,   spots: spendingMA,  isDashed: true),
+          ChartSeries(key: 'cf:cash',        name: s.dashCash,       color: Colors.green,          spots: cashSpots,   rightAxis: true),
         ],
         ctl: _spendingWinCtl,
         onWin: (int w) => setState(() => _spendingWindow = w),
@@ -175,9 +175,9 @@ class _CashFlowTabState extends ConsumerState<_CashFlowTab> {
       (
         id: _idVelocity,
         chart: _fakeChart(_idVelocity, '${s.cfVelocity} (MA)'),
-        series: <_Series>[
-          _Series(key: 'cf:saving_vel',   name: '${s.dashSaving} vel.',     color: Colors.blue, spots: savingVel),
-          _Series(key: 'cf:spending_vel', name: '${s.legendExpenses} vel.', color: Colors.red,  spots: spendingVel),
+        series: <ChartSeries>[
+          ChartSeries(key: 'cf:saving_vel',   name: '${s.dashSaving} vel.',     color: Colors.blue, spots: savingVel),
+          ChartSeries(key: 'cf:spending_vel', name: '${s.legendExpenses} vel.', color: Colors.red,  spots: spendingVel),
         ],
         ctl: _velocityWinCtl,
         onWin: (int w) => setState(() => _velocityWindow = w),

--- a/lib/ui/screens/dashboard/chart_card.dart
+++ b/lib/ui/screens/dashboard/chart_card.dart
@@ -6,8 +6,8 @@ part of 'dashboard_screen.dart';
 
 class _ChartCard extends ConsumerWidget {
   final DashboardChart chart;
-  final List<_Series> series;
-  final _AllSeriesData allData;
+  final List<ChartSeries> series;
+  final AllSeriesData allData;
   final Set<String> hidden;
   final bool hideComponents;
   final String locale;
@@ -47,7 +47,7 @@ class _ChartCard extends ConsumerWidget {
 
   /// Build total spots with smart asset handling:
   /// If both invested and market are visible for the same asset, only sum market.
-  List<FlSpot> _buildSmartTotalSpots(List<_Series> visible) {
+  List<FlSpot> _buildSmartTotalSpots(List<ChartSeries> visible) {
     // Find asset IDs that have both invested AND market visible
     final visibleInvestedIds = <int>{};
     final visibleMarketIds = <int>{};
@@ -84,7 +84,7 @@ class _ChartCard extends ConsumerWidget {
     final currFmt = fmt.currencyFormat(locale, symbol, decimalDigits: 0);
 
     // Series to actually draw (empty if hideComponents, but total is unaffected)
-    final drawnSeries = hideComponents ? <_Series>[] : visible;
+    final drawnSeries = hideComponents ? <ChartSeries>[] : visible;
 
     // Group series by type for legend
     final accountSeries = series.where((s) => s.key.startsWith('account:')).toList();
@@ -176,7 +176,7 @@ class _ChartCard extends ConsumerWidget {
                     final effectiveMinY = zoomMinY ?? (autoRange > 0 ? autoMinY - autoRange * 0.05 : autoMinY - 100);
                     final effectiveMaxY = zoomMaxY ?? (autoRange > 0 ? autoMaxY + autoRange * 0.05 : autoMaxY + 100);
 
-                    return _DragZoomWrapper(
+                    return DragZoomWrapper(
                       xMin: zoomMinX ?? 0,
                       xMax: zoomMaxX ?? (totalSpots.isNotEmpty ? totalSpots.last.x : 1),
                       yMin: effectiveMinY,
@@ -185,7 +185,7 @@ class _ChartCard extends ConsumerWidget {
                       baseCurrency: allData.baseCurrency,
                       locale: locale,
                       onZoom: onZoom,
-                      child: _UnifiedChart(
+                      child: UnifiedChart(
                         firstDate: allData.firstDate,
                         visible: drawnSeries,
                         totalSpots: totalSpots,
@@ -235,12 +235,12 @@ class _ChartCard extends ConsumerWidget {
 // ════════════════════════════════════════════════════
 
 class _ChartLegend extends StatelessWidget {
-  final List<_Series> accountSeries;
-  final List<_Series> investedSeries;
-  final List<_Series> marketSeries;
-  final List<_Series> adjustmentSeries;
-  final List<_Series> incomeAdjSeries;
-  final List<_Series> otherSeries; // e.g. cash-flow series with cf: prefix
+  final List<ChartSeries> accountSeries;
+  final List<ChartSeries> investedSeries;
+  final List<ChartSeries> marketSeries;
+  final List<ChartSeries> adjustmentSeries;
+  final List<ChartSeries> incomeAdjSeries;
+  final List<ChartSeries> otherSeries; // e.g. cash-flow series with cf: prefix
   final bool showTotalItem;
   final Set<String> hidden;
   final ValueChanged<String> onToggle;
@@ -303,7 +303,7 @@ class _ChartLegend extends StatelessWidget {
     );
   }
 
-  List<Widget> _buildGroup(BuildContext context, String label, List<_Series> series) {
+  List<Widget> _buildGroup(BuildContext context, String label, List<ChartSeries> series) {
     final keys = series.map((s) => s.key).toSet();
     final allHidden = keys.every(hidden.contains);
 
@@ -441,7 +441,7 @@ class _ToggleLegendItem extends StatelessWidget {
               SizedBox(
                 width: 12,
                 height: 3,
-                child: CustomPaint(painter: _DashedLinePainter(effectiveColor)),
+                child: CustomPaint(painter: DashedLinePainter(effectiveColor)),
               )
             else
               Container(width: 12, height: 3, color: effectiveColor),

--- a/lib/ui/screens/dashboard/dashboard_screen.dart
+++ b/lib/ui/screens/dashboard/dashboard_screen.dart
@@ -91,7 +91,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
 
   @override
   Widget build(BuildContext context) {
-    final allDataAsync = ref.watch(_allSeriesDataProvider);
+    final allDataAsync = ref.watch(allSeriesDataProvider);
     final locale = ref.watch(appLocaleProvider).value ?? Platform.localeName;
     final langCode = ref.watch(portableLanguageProvider);
     final language = langCode.startsWith('it') ? 'it_IT' : 'en_US';
@@ -124,7 +124,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
   }
 
   Widget _buildChartsTab(
-    AsyncValue<_AllSeriesData?> allDataAsync,
+    AsyncValue<AllSeriesData?> allDataAsync,
     String locale,
     String language,
     BuildContext context,
@@ -181,7 +181,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
             // Chart widgets
             final isCombined = chart.sourceChartIds != null;
 
-            List<_Series> filteredSeries;
+            List<ChartSeries> filteredSeries;
             if (isCombined) {
               filteredSeries = _buildCombinedSeries(charts, chart, allData);
             } else {
@@ -250,7 +250,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
   }
 
   Widget _buildCashFlowTab(
-    AsyncValue<_AllSeriesData?> allDataAsync,
+    AsyncValue<AllSeriesData?> allDataAsync,
     String locale,
     String language,
     BuildContext context,
@@ -274,10 +274,10 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
   /// Build the fixed set of dashboard widgets from live series data.
   /// Widget definitions are static; series are resolved dynamically from all
   /// active accounts, assets, and adjustments — no IDs are hardcoded.
-  List<DashboardChart> _buildStaticCharts(_AllSeriesData allData, AppStrings s) {
+  List<DashboardChart> _buildStaticCharts(AllSeriesData allData, AppStrings s) {
     final now = DateTime.now();
 
-    List<Map<String, dynamic>> toConfigs(List<_Series> series) => series.map((s) {
+    List<Map<String, dynamic>> toConfigs(List<ChartSeries> series) => series.map((s) {
           final parts = s.key.split(':');
           return {'type': parts[0], 'id': int.parse(parts[1])};
         }).toList();
@@ -345,7 +345,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
   }
 
   /// Build series for a combined chart: each source chart's total becomes a line.
-  List<_Series> _buildCombinedSeries(List<DashboardChart> allCharts, DashboardChart combined, _AllSeriesData allData) {
+  List<ChartSeries> _buildCombinedSeries(List<DashboardChart> allCharts, DashboardChart combined, AllSeriesData allData) {
     List<int> sourceIds;
     try {
       sourceIds = (jsonDecode(combined.sourceChartIds!) as List).cast<int>();
@@ -353,7 +353,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
       return [];
     }
 
-    final result = <_Series>[];
+    final result = <ChartSeries>[];
     var colorIdx = 0;
 
     for (final srcId in sourceIds) {
@@ -368,7 +368,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
       final totalSpots = _buildSmartTotalSpotsStatic(srcSeries);
       if (totalSpots.isEmpty) continue;
 
-      result.add(_Series(
+      result.add(ChartSeries(
         key: 'combined_src:$srcId',
         name: srcChart.title,
         color: _chartColors[colorIdx % _chartColors.length],
@@ -381,7 +381,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
   }
 
   /// Static version of smart total spots for use outside _ChartCard.
-  static List<FlSpot> _buildSmartTotalSpotsStatic(List<_Series> visible) {
+  static List<FlSpot> _buildSmartTotalSpotsStatic(List<ChartSeries> visible) {
     final visibleInvestedIds = <int>{};
     final visibleMarketIds = <int>{};
     for (final s in visible) {
@@ -414,8 +414,8 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen>
     }
   }
 
-  List<_Series> _filterSeries(_AllSeriesData allData, List<Map<String, dynamic>> configs) {
-    final result = <_Series>[];
+  List<ChartSeries> _filterSeries(AllSeriesData allData, List<Map<String, dynamic>> configs) {
+    final result = <ChartSeries>[];
     for (final config in configs) {
       final type = config['type'] as String?;
       final id = config['id'] as int?;

--- a/lib/ui/screens/dashboard/data_providers.dart
+++ b/lib/ui/screens/dashboard/data_providers.dart
@@ -4,7 +4,7 @@ part of 'dashboard_screen.dart';
 // Unified data provider — computes ALL series at once
 // ════════════════════════════════════════════════════
 
-final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
+final allSeriesDataProvider = FutureProvider<AllSeriesData?>((ref) async {
   final db = ref.watch(databaseProvider);
   final baseCurrency = await ref.watch(baseCurrencyProvider.future);
   final rateService = ref.watch(exchangeRateServiceProvider);
@@ -140,7 +140,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
   final firstDate = DateTime.fromMillisecondsSinceEpoch(sortedDays.first * 1000);
 
   // ── Build account series ──
-  final accountSeries = <_Series>[];
+  final accountSeries = <ChartSeries>[];
   for (final account in activeAccounts) {
     if (!perAccount.containsKey(account.id)) continue;
     final dayMap = perAccount[account.id]!;
@@ -157,7 +157,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
       }
     }
 
-    accountSeries.add(_Series(
+    accountSeries.add(ChartSeries(
       key: 'account:${account.id}',
       name: account.name,
       color: _chartColors[colorIdx % _chartColors.length],
@@ -167,7 +167,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
   }
 
   // ── Build asset invested series (cumulative) ──
-  final assetInvestedSeries = <_Series>[];
+  final assetInvestedSeries = <ChartSeries>[];
   for (final asset in activeAssets) {
     if (!perAssetDeltas.containsKey(asset.id)) continue;
     final deltaMap = perAssetDeltas[asset.id]!;
@@ -187,7 +187,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
       }
     }
 
-    assetInvestedSeries.add(_Series(
+    assetInvestedSeries.add(ChartSeries(
       key: 'asset_invested:${asset.id}',
       name: '${asset.ticker ?? asset.name} inv.',
       color: _chartColors[colorIdx % _chartColors.length],
@@ -267,7 +267,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
     return list[lo].$2;
   }
 
-  final assetMarketSeries = <_Series>[];
+  final assetMarketSeries = <ChartSeries>[];
   for (final asset in activeAssets) {
     if (!perAssetDeltas.containsKey(asset.id)) continue;
     final qtyDeltaMap = perAssetQtyDeltas[asset.id] ?? {};
@@ -314,7 +314,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
     final investedIdx = assetInvestedSeries.indexWhere((s) => s.key == 'asset_invested:${asset.id}');
     final color = investedIdx >= 0 ? assetInvestedSeries[investedIdx].color : _chartColors[colorIdx++ % _chartColors.length];
 
-    assetMarketSeries.add(_Series(
+    assetMarketSeries.add(ChartSeries(
       key: 'asset_market:${asset.id}',
       name: asset.ticker ?? asset.name,
       color: color,
@@ -323,7 +323,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
   }
 
   // ── Build asset gain series (market - invested) ──
-  final assetGainSeries = <_Series>[];
+  final assetGainSeries = <ChartSeries>[];
   for (final asset in activeAssets) {
     final invMatch = assetInvestedSeries.where((s) => s.key == 'asset_invested:${asset.id}');
     final mktMatch = assetMarketSeries.where((s) => s.key == 'asset_market:${asset.id}');
@@ -342,7 +342,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
       if (invLookup.containsKey(mkt.x)) lastInv = invLookup[mkt.x]!;
       gainSpots.add(FlSpot(mkt.x, mkt.y - lastInv));
     }
-    assetGainSeries.add(_Series(
+    assetGainSeries.add(ChartSeries(
       key: 'asset_gain:${asset.id}',
       name: asset.ticker ?? asset.name,
       color: mktMatch.first.color,
@@ -382,7 +382,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
     }
   }
 
-  final adjustmentSeries = <_Series>[];
+  final adjustmentSeries = <ChartSeries>[];
 
   for (final schedule in activeSchedules) {
     final entries = allScheduleEntries[schedule.id] ?? [];
@@ -427,7 +427,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
       prevY = y;
     }
 
-    adjustmentSeries.add(_Series(
+    adjustmentSeries.add(ChartSeries(
       key: 'adjustment:${schedule.id}',
       name: schedule.assetName,
       color: _chartColors[colorIdx % _chartColors.length],
@@ -456,7 +456,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
     }
   }
 
-  final incomeAdjSeries = <_Series>[];
+  final incomeAdjSeries = <ChartSeries>[];
 
   for (final adj in activeIncomeAdj) {
     final expenses = allAdjExpenses[adj.id] ?? [];
@@ -495,7 +495,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
       prevY = y;
     }
 
-    incomeAdjSeries.add(_Series(
+    incomeAdjSeries.add(ChartSeries(
       key: 'income_adj:${adj.id}',
       name: adj.name,
       color: _chartColors[colorIdx % _chartColors.length],
@@ -505,7 +505,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
     colorIdx++;
   }
 
-  return _AllSeriesData(
+  return AllSeriesData(
     firstDate: firstDate,
     accounts: accountSeries,
     assetInvested: assetInvestedSeries,
@@ -522,7 +522,7 @@ final _allSeriesDataProvider = FutureProvider<_AllSeriesData?>((ref) async {
 // ════════════════════════════════════════════════════
 
 final _incomeExpenseDataProvider = FutureProvider<_IncomeExpenseData?>((ref) async {
-  final allSeriesData = await ref.watch(_allSeriesDataProvider.future);
+  final allSeriesData = await ref.watch(allSeriesDataProvider.future);
   if (allSeriesData == null) return null;
 
   final db = ref.watch(databaseProvider);

--- a/lib/ui/screens/dashboard/models.dart
+++ b/lib/ui/screens/dashboard/models.dart
@@ -5,14 +5,14 @@ part of 'dashboard_screen.dart';
 // ════════════════════════════════════════════════════
 
 /// Unified series for accounts, assets, and CAPEX.
-class _Series {
+class ChartSeries {
   final String key; // unique id for toggling: "a:3" (account), "s:7" (asset), "c:1" (capex)
   final String name;
   final Color color;
   final List<FlSpot> spots;
   final bool isDashed;
   final bool rightAxis; // true → scale into left pixel space, show on right Y-axis
-  const _Series({
+  const ChartSeries({
     required this.key,
     required this.name,
     required this.color,
@@ -23,17 +23,17 @@ class _Series {
 }
 
 /// All chart data: account series, asset series, CAPEX series, market value series.
-class _AllSeriesData {
+class AllSeriesData {
   final DateTime firstDate;
-  final List<_Series> accounts;      // key: "account:<id>"
-  final List<_Series> assetInvested; // key: "asset_invested:<id>"
-  final List<_Series> assetMarket;   // key: "asset_market:<id>"
-  final List<_Series> assetGain;     // key: "asset_gain:<id>"  (market - invested)
-  final List<_Series> adjustments;      // key: "adjustment:<id>"
-  final List<_Series> incomeAdjustments; // key: "income_adj:<id>"
+  final List<ChartSeries> accounts;      // key: "account:<id>"
+  final List<ChartSeries> assetInvested; // key: "asset_invested:<id>"
+  final List<ChartSeries> assetMarket;   // key: "asset_market:<id>"
+  final List<ChartSeries> assetGain;     // key: "asset_gain:<id>"  (market - invested)
+  final List<ChartSeries> adjustments;      // key: "adjustment:<id>"
+  final List<ChartSeries> incomeAdjustments; // key: "income_adj:<id>"
   final String baseCurrency;
 
-  const _AllSeriesData({
+  const AllSeriesData({
     required this.firstDate,
     required this.accounts,
     required this.assetInvested,
@@ -44,7 +44,7 @@ class _AllSeriesData {
     required this.baseCurrency,
   });
 
-  List<_Series> get allSeries => [...accounts, ...assetInvested, ...assetMarket, ...assetGain, ...adjustments, ...incomeAdjustments];
+  List<ChartSeries> get allSeries => [...accounts, ...assetInvested, ...assetMarket, ...assetGain, ...adjustments, ...incomeAdjustments];
 }
 
 // ════════════════════════════════════════════════════

--- a/lib/ui/screens/dashboard/totals_table.dart
+++ b/lib/ui/screens/dashboard/totals_table.dart
@@ -5,7 +5,7 @@ part of 'dashboard_screen.dart';
 // ════════════════════════════════════════════════════
 
 class _SummaryTotalsTable extends ConsumerStatefulWidget {
-  final _AllSeriesData allData;
+  final AllSeriesData allData;
   final String locale;
 
   const _SummaryTotalsTable({required this.allData, required this.locale});
@@ -174,7 +174,7 @@ class _SummaryTotalsTableState extends ConsumerState<_SummaryTotalsTable> {
     return Icons.circle;
   }
 
-  List<Widget> _buildDrillDown(List<_Series> series, NumberFormat amtFmt, ThemeData theme) {
+  List<Widget> _buildDrillDown(List<ChartSeries> series, NumberFormat amtFmt, ThemeData theme) {
     final items = <({String key, String name, double value})>[];
     for (final s in series) {
       final val = s.spots.isNotEmpty ? s.spots.last.y : 0.0;
@@ -211,6 +211,6 @@ class _TotalRow {
   final String label;
   final double total;
   final double deltaVsMax; // current - historical max (excluding today)
-  final List<_Series> series;
+  final List<ChartSeries> series;
   const _TotalRow(this.label, this.total, this.deltaVsMax, this.series);
 }

--- a/lib/ui/screens/dashboard/unified_chart.dart
+++ b/lib/ui/screens/dashboard/unified_chart.dart
@@ -1,8 +1,8 @@
 part of 'dashboard_screen.dart';
 
-class _DashedLinePainter extends CustomPainter {
+class DashedLinePainter extends CustomPainter {
   final Color color;
-  _DashedLinePainter(this.color);
+  DashedLinePainter(this.color);
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -30,7 +30,7 @@ class _DashedLinePainter extends CustomPainter {
 // Drag-to-zoom wrapper (CloudWatch style)
 // ════════════════════════════════════════════════════
 
-class _DragZoomWrapper extends StatefulWidget {
+class DragZoomWrapper extends StatefulWidget {
   final Widget child;
   final double xMin;
   final double xMax;
@@ -43,7 +43,7 @@ class _DragZoomWrapper extends StatefulWidget {
   final String locale;
   final void Function(double? minX, double? maxX, double? minY, double? maxY) onZoom;
 
-  const _DragZoomWrapper({
+  const DragZoomWrapper({super.key, 
     required this.child,
     required this.xMin,
     required this.xMax,
@@ -56,10 +56,10 @@ class _DragZoomWrapper extends StatefulWidget {
   });
 
   @override
-  State<_DragZoomWrapper> createState() => _DragZoomWrapperState();
+  State<DragZoomWrapper> createState() => _DragZoomWrapperState();
 }
 
-class _DragZoomWrapperState extends State<_DragZoomWrapper> {
+class _DragZoomWrapperState extends State<DragZoomWrapper> {
   Offset? _dragStart;
   Offset? _dragCurrent;
   bool _isDragging = false;
@@ -184,9 +184,9 @@ class _DragZoomWrapperState extends State<_DragZoomWrapper> {
 // Unified chart widget
 // ════════════════════════════════════════════════════
 
-class _UnifiedChart extends StatelessWidget {
+class UnifiedChart extends StatelessWidget {
   final DateTime firstDate;
-  final List<_Series> visible;
+  final List<ChartSeries> visible;
   final List<FlSpot> totalSpots;
   final bool showTotal;
   final String baseCurrency;
@@ -198,7 +198,7 @@ class _UnifiedChart extends StatelessWidget {
   final double? zoomMaxY;
   final bool isPrivate;
 
-  const _UnifiedChart({
+  const UnifiedChart({super.key, 
     required this.firstDate,
     required this.visible,
     required this.totalSpots,

--- a/test/chart_models_test.dart
+++ b/test/chart_models_test.dart
@@ -1,0 +1,85 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:finance_copilot/ui/screens/dashboard/dashboard_screen.dart'
+    show ChartSeries, buildTotalSpots, toDayKey;
+
+void main() {
+  group('ChartSeries', () {
+    test('stores fields correctly', () {
+      final series = ChartSeries(
+        key: 'asset_market:1',
+        name: 'VWCE',
+        color: Colors.blue,
+        spots: [const FlSpot(0, 100), const FlSpot(10, 120)],
+      );
+      expect(series.key, 'asset_market:1');
+      expect(series.name, 'VWCE');
+      expect(series.color, Colors.blue);
+      expect(series.spots.length, 2);
+      expect(series.isDashed, false);
+      expect(series.rightAxis, false);
+    });
+
+    test('isDashed and rightAxis flags work', () {
+      final series = ChartSeries(
+        key: 'cf:vel',
+        name: 'Velocity',
+        color: Colors.red,
+        spots: [],
+        isDashed: true,
+        rightAxis: true,
+      );
+      expect(series.isDashed, true);
+      expect(series.rightAxis, true);
+    });
+  });
+
+  group('buildTotalSpots', () {
+    test('returns empty for empty input', () {
+      expect(buildTotalSpots([]), isEmpty);
+    });
+
+    test('single series returns same spots', () {
+      final spots = [const FlSpot(0, 10), const FlSpot(5, 20)];
+      final total = buildTotalSpots([spots]);
+      expect(total.length, 2);
+      expect(total[0].y, 10);
+      expect(total[1].y, 20);
+    });
+
+    test('two series sums values at same x', () {
+      final s1 = [const FlSpot(0, 10), const FlSpot(5, 20)];
+      final s2 = [const FlSpot(0, 5), const FlSpot(5, 15)];
+      final total = buildTotalSpots([s1, s2]);
+      expect(total.length, 2);
+      expect(total[0].y, 15); // 10 + 5
+      expect(total[1].y, 35); // 20 + 15
+    });
+
+    test('carry-forward fills gaps', () {
+      final s1 = [const FlSpot(0, 10), const FlSpot(5, 20)];
+      final s2 = [const FlSpot(0, 5)]; // no value at x=5
+      final total = buildTotalSpots([s1, s2]);
+      expect(total.length, 2);
+      expect(total[0].y, 15); // 10 + 5
+      expect(total[1].y, 25); // 20 + 5 (carry-forward)
+    });
+  });
+
+  group('toDayKey', () {
+    test('truncates to midnight epoch seconds', () {
+      final dt = DateTime(2024, 6, 15, 14, 30, 45);
+      final key = toDayKey(dt);
+      final midnight = DateTime(2024, 6, 15).millisecondsSinceEpoch ~/ 1000;
+      expect(key, midnight);
+    });
+
+    test('same day different times produce same key', () {
+      final a = toDayKey(DateTime(2024, 1, 1, 0, 0, 0));
+      final b = toDayKey(DateTime(2024, 1, 1, 23, 59, 59));
+      expect(a, b);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Two collapsible charts on asset detail screen (between info card and composition)
  - **Asset chart**: invested (dashed orange) vs market value (solid blue) in base currency
  - **Price chart**: raw asset price in its native currency (like a stock chart)
- Refactored dashboard chart internals to public scope (`ChartSeries`, `UnifiedChart`, `DragZoomWrapper`, `AllSeriesData`, `allSeriesDataProvider`) for reuse
- Single-asset provider filters the shared dashboard data — no duplicated financial logic
- X-axis starts at first event date per asset, no empty space

## Test plan
- [x] 442 unit tests pass (8 new for `ChartSeries`, `buildTotalSpots`, `toDayKey`)
- [ ] Integration tests (CI/CD)
- [ ] Manual: open asset detail, expand both charts, verify data matches dashboard
- [ ] Manual: drag-to-zoom works, double-tap resets
- [ ] Manual: privacy mode hides values