### PR TITLE
CI: skip tests on tag pushes, build directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test:
+    if: "!startsWith(github.ref, 'refs/tags/v')"
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
@@ -38,6 +39,7 @@ jobs:
         run: flutter test
 
   integration-test:
+    if: "!startsWith(github.ref, 'refs/tags/v')"
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +79,7 @@ jobs:
         run: flutter test integration_test/live_data_fetch_test.dart -d macos
 
   integration-test-android:
+    if: "!startsWith(github.ref, 'refs/tags/v')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -130,7 +133,7 @@ jobs:
 
   build:
     needs: [test, integration-test, integration-test-android]
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
+    if: always() && !failure() && !cancelled() && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch')
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- Skip test/integration-test jobs on tag pushes (tests already passed on the PR)
- Build job runs immediately on tags, saving ~15 minutes per release
- No behavior change for PRs or develop pushes

## Test plan
- [x] PR CI still runs all test jobs (this PR proves it)
- [ ] Next tag push should skip tests and go straight to build