### PR TITLE
v0.7.0: import fixes, schema v27-v30, UI restructure, explicit Drive backup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop]
     tags: ['v*']
   pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     if: "!startsWith(github.ref, 'refs/tags/v')"

--- a/integration_test/helpers/test_app.dart
+++ b/integration_test/helpers/test_app.dart
@@ -55,6 +55,11 @@ Future<AppDatabase> pumpApp(
     }
   }
 
+  // Seed a default intermediary (required by assets since schema v29).
+  await db.into(db.intermediaries).insert(IntermediariesCompanion.insert(
+    name: 'Default',
+  ));
+
   // Seed a dummy account so the landing page doesn't show (empty DB check)
   await db.into(db.accounts).insert(AccountsCompanion.insert(
     name: '_test_seed', sortOrder: const Value(999),
@@ -214,12 +219,14 @@ Future<int> seedAsset(
   String? exchange,
   String? currency,
 }) async {
+  final intermediaries = await db.select(db.intermediaries).get();
   return db.into(db.assets).insert(AssetsCompanion.insert(
         name: name,
         assetType: AssetType.stockEtf,
         instrumentType: const Value(InstrumentType.etf),
         assetClass: const Value(AssetClass.equity),
         valuationMethod: ValuationMethod.marketPrice,
+        intermediaryId: intermediaries.first.id,
         isin: Value(isin),
         ticker: Value(ticker),
         exchange: Value(exchange),

--- a/integration_test/helpers/test_app.dart
+++ b/integration_test/helpers/test_app.dart
@@ -282,6 +282,31 @@ Future<int> seedIncome(AppDatabase db, {double amount = 1000.0}) async {
       ));
 }
 
+/// Tap the "Default" intermediary radio in the Confirm step of asset
+/// imports. Required since schema v29 (asset imports refuse to proceed
+/// without an intermediary). Assumes pumpApp seeded the "Default" name.
+Future<void> selectDefaultIntermediary(WidgetTester tester) async {
+  final defaultRadio = find.text('Default');
+  await tester.ensureVisible(defaultRadio.first);
+  await settle(tester);
+  await tester.tap(defaultRadio.first);
+  await settle(tester);
+}
+
+/// Pick a number-format locale from the Confirm step dropdown (schema v30).
+/// Needed when the import fixture uses a format different from the test app
+/// locale — e.g. comma-decimal European data on an en_US test environment.
+/// Pass the label shown in the menu, e.g. 'Italiano (it_IT)'.
+Future<void> selectImportLocale(WidgetTester tester, String label) async {
+  final dropdown = find.byType(DropdownButton<String?>);
+  await tester.ensureVisible(dropdown.first);
+  await settle(tester);
+  await tester.tap(dropdown.first);
+  await settle(tester);
+  await tester.tap(find.text(label).last);
+  await settle(tester);
+}
+
 /// Tap Buy/Sell ChoiceChips for asset type-from-column mapping.
 /// First row's value → Buy, second row's value → Sell.
 Future<void> tapBuySellChips(WidgetTester tester) async {

--- a/integration_test/import_asset_test.dart
+++ b/integration_test/import_asset_test.dart
@@ -31,6 +31,8 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
     }
 
+    await selectDefaultIntermediary(tester);
+
     await tester.ensureVisible(find.widgetWithText(FilledButton, 'Import'));
     await tester.tap(find.widgetWithText(FilledButton, 'Import'));
     for (var i = 0; i < 30; i++) {
@@ -65,6 +67,9 @@ void main() {
     for (var i = 0; i < 10; i++) {
       await tester.pump(const Duration(milliseconds: 100));
     }
+
+    await selectDefaultIntermediary(tester);
+    await selectImportLocale(tester, 'Italiano (it_IT)');
 
     await tester.ensureVisible(find.widgetWithText(FilledButton, 'Import'));
     await tester.tap(find.widgetWithText(FilledButton, 'Import'));
@@ -104,6 +109,8 @@ void main() {
     for (var i = 0; i < 10; i++) {
       await tester.pump(const Duration(milliseconds: 100));
     }
+
+    await selectDefaultIntermediary(tester);
 
     await tester.ensureVisible(find.widgetWithText(FilledButton, 'Import'));
     await tester.tap(find.widgetWithText(FilledButton, 'Import'));
@@ -158,6 +165,8 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
     }
 
+    await selectDefaultIntermediary(tester);
+
     final scrollable = find.byType(Scrollable);
     if (scrollable.evaluate().isNotEmpty) {
       await tester.drag(scrollable.last, const Offset(0, -300));
@@ -208,12 +217,16 @@ void main() {
 
     final excludeIsin = find.text('IE00BKM4GZ66');
     expect(excludeIsin, findsOneWidget);
+    await tester.ensureVisible(excludeIsin);
+    await settle(tester);
     final isinRow = find.ancestor(of: excludeIsin, matching: find.byType(Row));
     final checkbox = find.descendant(of: isinRow.first, matching: find.byType(Checkbox));
     if (checkbox.evaluate().isNotEmpty) {
       await tester.tap(checkbox.first);
       await settle(tester);
     }
+
+    await selectDefaultIntermediary(tester);
 
     await tester.ensureVisible(find.widgetWithText(FilledButton, 'Import'));
     await tester.tap(find.widgetWithText(FilledButton, 'Import'));

--- a/integration_test/import_csv_test.dart
+++ b/integration_test/import_csv_test.dart
@@ -16,6 +16,8 @@ void main() {
     final importer = ImportService(db);
     final accounts = await db.select(db.accounts).get();
     final accountId = accounts.first.id;
+    final intermediaries = await db.select(db.intermediaries).get();
+    final intermediaryId = intermediaries.first.id;
 
     // -- Import transactions --
     final txPreview = makePreview('''Date,Amount,Description
@@ -57,6 +59,7 @@ void main() {
         ColumnMapping(sourceColumn: 'amount', targetField: 'amount'),
       ],
       baseCurrency: 'EUR',
+      intermediaryId: intermediaryId,
     );
 
     expect(assetResult.result.importedRows, 3);

--- a/integration_test/import_transaction_test.dart
+++ b/integration_test/import_transaction_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'package:finance_copilot/database/database.dart';
 import 'package:finance_copilot/services/import_service.dart';
 
 import 'helpers/test_app.dart';
@@ -67,6 +68,10 @@ void main() {
 
   testWidgets('Import CSV: European format (semicolon, comma decimal)', (tester) async {
     final db = await pumpApp(tester, seed: (db) async {
+      // Italian-locale user importing an Italian-locale file.
+      await db.into(db.appConfigs).insertOnConflictUpdate(
+            AppConfigsCompanion.insert(key: 'LOCALE', value: 'it_IT'),
+          );
       await seedAccount(db, name: 'EU Bank');
     });
 

--- a/integration_test/live_data_fetch_test.dart
+++ b/integration_test/live_data_fetch_test.dart
@@ -192,12 +192,14 @@ Future<int> _seedStock(
   String exchange = 'MIL',
   String currency = 'EUR',
 }) async {
+  final intermediaries = await db.select(db.intermediaries).get();
   return db.into(db.assets).insert(AssetsCompanion.insert(
     name: name,
     assetType: AssetType.stockEtf,
     instrumentType: const Value(InstrumentType.stock),
     assetClass: const Value(AssetClass.equity),
     valuationMethod: ValuationMethod.marketPrice,
+    intermediaryId: intermediaries.first.id,
     isin: Value(isin),
     ticker: Value(ticker),
     exchange: Value(exchange),
@@ -214,12 +216,14 @@ Future<int> _seedBond(
   String exchange = 'MIL',
   String currency = 'EUR',
 }) async {
+  final intermediaries = await db.select(db.intermediaries).get();
   return db.into(db.assets).insert(AssetsCompanion.insert(
     name: name,
     assetType: AssetType.stockEtf,
     instrumentType: const Value(InstrumentType.bond),
     assetClass: const Value(AssetClass.fixedIncome),
     valuationMethod: ValuationMethod.marketPrice,
+    intermediaryId: intermediaries.first.id,
     isin: Value(isin),
     exchange: Value(exchange),
     currency: Value(currency),

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -54,7 +54,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 28;
+  int get schemaVersion => 29;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -399,6 +399,39 @@ class AppDatabase extends _$AppDatabase {
             }
             _log.info('Migration 28: dropped legacy CAPEX/IncomeAdj tables, '
                 'renamed buffers FK, dropped transactions.depreciation_id');
+          }
+          if (from < 29) {
+            // Every asset must now have an intermediary. Any asset currently
+            // without one is moved to a "Default" intermediary created on the
+            // fly (or reused if it already exists).
+            final orphanCount = (await customSelect(
+              'SELECT COUNT(*) AS c FROM assets WHERE intermediary_id IS NULL',
+            ).getSingle()).read<int>('c');
+
+            if (orphanCount > 0) {
+              // Find or create the Default intermediary.
+              final existing = await customSelect(
+                "SELECT id FROM intermediaries WHERE name = 'Default' LIMIT 1",
+              ).getSingleOrNull();
+              int defaultId;
+              if (existing != null) {
+                defaultId = existing.read<int>('id');
+              } else {
+                await customStatement(
+                  "INSERT INTO intermediaries (name) VALUES ('Default')",
+                );
+                defaultId = (await customSelect(
+                  "SELECT id FROM intermediaries WHERE name = 'Default' LIMIT 1",
+                ).getSingle()).read<int>('id');
+              }
+              await customStatement(
+                'UPDATE assets SET intermediary_id = ? WHERE intermediary_id IS NULL',
+                [defaultId],
+              );
+              _log.info('Migration 29: moved $orphanCount orphan assets to Default intermediary (id=$defaultId)');
+            } else {
+              _log.info('Migration 29: no orphan assets to backfill');
+            }
           }
         },
       );

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -54,7 +54,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 29;
+  int get schemaVersion => 30;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -432,6 +432,21 @@ class AppDatabase extends _$AppDatabase {
             } else {
               _log.info('Migration 29: no orphan assets to backfill');
             }
+          }
+          if (from < 30) {
+            // Per-source number-format locale for imports. NULL means
+            // "Auto — use the app's configured locale at import time".
+            if (!await _hasColumn('import_configs', 'number_locale')) {
+              await customStatement(
+                'ALTER TABLE import_configs ADD COLUMN number_locale TEXT',
+              );
+            }
+            if (!await _hasColumn('intermediaries', 'default_import_locale')) {
+              await customStatement(
+                'ALTER TABLE intermediaries ADD COLUMN default_import_locale TEXT',
+              );
+            }
+            _log.info('Migration 30: added number_locale columns');
           }
         },
       );

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -47,6 +47,17 @@ class $IntermediariesTable extends Intermediaries
     requiredDuringInsert: false,
     defaultValue: const Constant(0),
   );
+  static const VerificationMeta _defaultImportLocaleMeta =
+      const VerificationMeta('defaultImportLocale');
+  @override
+  late final GeneratedColumn<String> defaultImportLocale =
+      GeneratedColumn<String>(
+        'default_import_locale',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
   static const VerificationMeta _createdAtMeta = const VerificationMeta(
     'createdAt',
   );
@@ -76,6 +87,7 @@ class $IntermediariesTable extends Intermediaries
     id,
     name,
     sortOrder,
+    defaultImportLocale,
     createdAt,
     updatedAt,
   ];
@@ -106,6 +118,15 @@ class $IntermediariesTable extends Intermediaries
       context.handle(
         _sortOrderMeta,
         sortOrder.isAcceptableOrUnknown(data['sort_order']!, _sortOrderMeta),
+      );
+    }
+    if (data.containsKey('default_import_locale')) {
+      context.handle(
+        _defaultImportLocaleMeta,
+        defaultImportLocale.isAcceptableOrUnknown(
+          data['default_import_locale']!,
+          _defaultImportLocaleMeta,
+        ),
       );
     }
     if (data.containsKey('created_at')) {
@@ -141,6 +162,10 @@ class $IntermediariesTable extends Intermediaries
         DriftSqlType.int,
         data['${effectivePrefix}sort_order'],
       )!,
+      defaultImportLocale: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}default_import_locale'],
+      ),
       createdAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}created_at'],
@@ -162,12 +187,18 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
   final int id;
   final String name;
   final int sortOrder;
+
+  /// Number-format locale used to parse asset-event imports under this
+  /// intermediary (e.g. 'it_IT', 'en_US'). NULL means "Auto — use the
+  /// app locale".
+  final String? defaultImportLocale;
   final DateTime createdAt;
   final DateTime updatedAt;
   const Intermediary({
     required this.id,
     required this.name,
     required this.sortOrder,
+    this.defaultImportLocale,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -177,6 +208,9 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
     map['id'] = Variable<int>(id);
     map['name'] = Variable<String>(name);
     map['sort_order'] = Variable<int>(sortOrder);
+    if (!nullToAbsent || defaultImportLocale != null) {
+      map['default_import_locale'] = Variable<String>(defaultImportLocale);
+    }
     map['created_at'] = Variable<DateTime>(createdAt);
     map['updated_at'] = Variable<DateTime>(updatedAt);
     return map;
@@ -187,6 +221,9 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
       id: Value(id),
       name: Value(name),
       sortOrder: Value(sortOrder),
+      defaultImportLocale: defaultImportLocale == null && nullToAbsent
+          ? const Value.absent()
+          : Value(defaultImportLocale),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
     );
@@ -201,6 +238,9 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
       id: serializer.fromJson<int>(json['id']),
       name: serializer.fromJson<String>(json['name']),
       sortOrder: serializer.fromJson<int>(json['sortOrder']),
+      defaultImportLocale: serializer.fromJson<String?>(
+        json['defaultImportLocale'],
+      ),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
     );
@@ -212,6 +252,7 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
       'id': serializer.toJson<int>(id),
       'name': serializer.toJson<String>(name),
       'sortOrder': serializer.toJson<int>(sortOrder),
+      'defaultImportLocale': serializer.toJson<String?>(defaultImportLocale),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
     };
@@ -221,12 +262,16 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
     int? id,
     String? name,
     int? sortOrder,
+    Value<String?> defaultImportLocale = const Value.absent(),
     DateTime? createdAt,
     DateTime? updatedAt,
   }) => Intermediary(
     id: id ?? this.id,
     name: name ?? this.name,
     sortOrder: sortOrder ?? this.sortOrder,
+    defaultImportLocale: defaultImportLocale.present
+        ? defaultImportLocale.value
+        : this.defaultImportLocale,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
   );
@@ -235,6 +280,9 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
       id: data.id.present ? data.id.value : this.id,
       name: data.name.present ? data.name.value : this.name,
       sortOrder: data.sortOrder.present ? data.sortOrder.value : this.sortOrder,
+      defaultImportLocale: data.defaultImportLocale.present
+          ? data.defaultImportLocale.value
+          : this.defaultImportLocale,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -246,6 +294,7 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
           ..write('id: $id, ')
           ..write('name: $name, ')
           ..write('sortOrder: $sortOrder, ')
+          ..write('defaultImportLocale: $defaultImportLocale, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
@@ -253,7 +302,14 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
   }
 
   @override
-  int get hashCode => Object.hash(id, name, sortOrder, createdAt, updatedAt);
+  int get hashCode => Object.hash(
+    id,
+    name,
+    sortOrder,
+    defaultImportLocale,
+    createdAt,
+    updatedAt,
+  );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -261,6 +317,7 @@ class Intermediary extends DataClass implements Insertable<Intermediary> {
           other.id == this.id &&
           other.name == this.name &&
           other.sortOrder == this.sortOrder &&
+          other.defaultImportLocale == this.defaultImportLocale &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt);
 }
@@ -269,12 +326,14 @@ class IntermediariesCompanion extends UpdateCompanion<Intermediary> {
   final Value<int> id;
   final Value<String> name;
   final Value<int> sortOrder;
+  final Value<String?> defaultImportLocale;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
   const IntermediariesCompanion({
     this.id = const Value.absent(),
     this.name = const Value.absent(),
     this.sortOrder = const Value.absent(),
+    this.defaultImportLocale = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
   });
@@ -282,6 +341,7 @@ class IntermediariesCompanion extends UpdateCompanion<Intermediary> {
     this.id = const Value.absent(),
     required String name,
     this.sortOrder = const Value.absent(),
+    this.defaultImportLocale = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
   }) : name = Value(name);
@@ -289,6 +349,7 @@ class IntermediariesCompanion extends UpdateCompanion<Intermediary> {
     Expression<int>? id,
     Expression<String>? name,
     Expression<int>? sortOrder,
+    Expression<String>? defaultImportLocale,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
   }) {
@@ -296,6 +357,8 @@ class IntermediariesCompanion extends UpdateCompanion<Intermediary> {
       if (id != null) 'id': id,
       if (name != null) 'name': name,
       if (sortOrder != null) 'sort_order': sortOrder,
+      if (defaultImportLocale != null)
+        'default_import_locale': defaultImportLocale,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
     });
@@ -305,6 +368,7 @@ class IntermediariesCompanion extends UpdateCompanion<Intermediary> {
     Value<int>? id,
     Value<String>? name,
     Value<int>? sortOrder,
+    Value<String?>? defaultImportLocale,
     Value<DateTime>? createdAt,
     Value<DateTime>? updatedAt,
   }) {
@@ -312,6 +376,7 @@ class IntermediariesCompanion extends UpdateCompanion<Intermediary> {
       id: id ?? this.id,
       name: name ?? this.name,
       sortOrder: sortOrder ?? this.sortOrder,
+      defaultImportLocale: defaultImportLocale ?? this.defaultImportLocale,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -329,6 +394,11 @@ class IntermediariesCompanion extends UpdateCompanion<Intermediary> {
     if (sortOrder.present) {
       map['sort_order'] = Variable<int>(sortOrder.value);
     }
+    if (defaultImportLocale.present) {
+      map['default_import_locale'] = Variable<String>(
+        defaultImportLocale.value,
+      );
+    }
     if (createdAt.present) {
       map['created_at'] = Variable<DateTime>(createdAt.value);
     }
@@ -344,6 +414,7 @@ class IntermediariesCompanion extends UpdateCompanion<Intermediary> {
           ..write('id: $id, ')
           ..write('name: $name, ')
           ..write('sortOrder: $sortOrder, ')
+          ..write('defaultImportLocale: $defaultImportLocale, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
@@ -9278,6 +9349,17 @@ class $ImportConfigsTable extends ImportConfigs
     requiredDuringInsert: false,
     defaultValue: const Constant('[]'),
   );
+  static const VerificationMeta _numberLocaleMeta = const VerificationMeta(
+    'numberLocale',
+  );
+  @override
+  late final GeneratedColumn<String> numberLocale = GeneratedColumn<String>(
+    'number_locale',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _updatedAtMeta = const VerificationMeta(
     'updatedAt',
   );
@@ -9298,6 +9380,7 @@ class $ImportConfigsTable extends ImportConfigs
     mappingsJson,
     formulaJson,
     hashColumnsJson,
+    numberLocale,
     updatedAt,
   ];
   @override
@@ -9356,6 +9439,15 @@ class $ImportConfigsTable extends ImportConfigs
         ),
       );
     }
+    if (data.containsKey('number_locale')) {
+      context.handle(
+        _numberLocaleMeta,
+        numberLocale.isAcceptableOrUnknown(
+          data['number_locale']!,
+          _numberLocaleMeta,
+        ),
+      );
+    }
     if (data.containsKey('updated_at')) {
       context.handle(
         _updatedAtMeta,
@@ -9395,6 +9487,10 @@ class $ImportConfigsTable extends ImportConfigs
         DriftSqlType.string,
         data['${effectivePrefix}hash_columns_json'],
       )!,
+      numberLocale: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}number_locale'],
+      ),
       updatedAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}updated_at'],
@@ -9415,6 +9511,10 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
   final String mappingsJson;
   final String formulaJson;
   final String hashColumnsJson;
+
+  /// Number-format locale used to parse this account's import files
+  /// (e.g. 'it_IT', 'en_US'). NULL means "Auto — use the app locale".
+  final String? numberLocale;
   final DateTime updatedAt;
   const ImportConfig({
     required this.id,
@@ -9423,6 +9523,7 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
     required this.mappingsJson,
     required this.formulaJson,
     required this.hashColumnsJson,
+    this.numberLocale,
     required this.updatedAt,
   });
   @override
@@ -9434,6 +9535,9 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
     map['mappings_json'] = Variable<String>(mappingsJson);
     map['formula_json'] = Variable<String>(formulaJson);
     map['hash_columns_json'] = Variable<String>(hashColumnsJson);
+    if (!nullToAbsent || numberLocale != null) {
+      map['number_locale'] = Variable<String>(numberLocale);
+    }
     map['updated_at'] = Variable<DateTime>(updatedAt);
     return map;
   }
@@ -9446,6 +9550,9 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
       mappingsJson: Value(mappingsJson),
       formulaJson: Value(formulaJson),
       hashColumnsJson: Value(hashColumnsJson),
+      numberLocale: numberLocale == null && nullToAbsent
+          ? const Value.absent()
+          : Value(numberLocale),
       updatedAt: Value(updatedAt),
     );
   }
@@ -9462,6 +9569,7 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
       mappingsJson: serializer.fromJson<String>(json['mappingsJson']),
       formulaJson: serializer.fromJson<String>(json['formulaJson']),
       hashColumnsJson: serializer.fromJson<String>(json['hashColumnsJson']),
+      numberLocale: serializer.fromJson<String?>(json['numberLocale']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
     );
   }
@@ -9475,6 +9583,7 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
       'mappingsJson': serializer.toJson<String>(mappingsJson),
       'formulaJson': serializer.toJson<String>(formulaJson),
       'hashColumnsJson': serializer.toJson<String>(hashColumnsJson),
+      'numberLocale': serializer.toJson<String?>(numberLocale),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
     };
   }
@@ -9486,6 +9595,7 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
     String? mappingsJson,
     String? formulaJson,
     String? hashColumnsJson,
+    Value<String?> numberLocale = const Value.absent(),
     DateTime? updatedAt,
   }) => ImportConfig(
     id: id ?? this.id,
@@ -9494,6 +9604,7 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
     mappingsJson: mappingsJson ?? this.mappingsJson,
     formulaJson: formulaJson ?? this.formulaJson,
     hashColumnsJson: hashColumnsJson ?? this.hashColumnsJson,
+    numberLocale: numberLocale.present ? numberLocale.value : this.numberLocale,
     updatedAt: updatedAt ?? this.updatedAt,
   );
   ImportConfig copyWithCompanion(ImportConfigsCompanion data) {
@@ -9510,6 +9621,9 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
       hashColumnsJson: data.hashColumnsJson.present
           ? data.hashColumnsJson.value
           : this.hashColumnsJson,
+      numberLocale: data.numberLocale.present
+          ? data.numberLocale.value
+          : this.numberLocale,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
   }
@@ -9523,6 +9637,7 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
           ..write('mappingsJson: $mappingsJson, ')
           ..write('formulaJson: $formulaJson, ')
           ..write('hashColumnsJson: $hashColumnsJson, ')
+          ..write('numberLocale: $numberLocale, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
         .toString();
@@ -9536,6 +9651,7 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
     mappingsJson,
     formulaJson,
     hashColumnsJson,
+    numberLocale,
     updatedAt,
   );
   @override
@@ -9548,6 +9664,7 @@ class ImportConfig extends DataClass implements Insertable<ImportConfig> {
           other.mappingsJson == this.mappingsJson &&
           other.formulaJson == this.formulaJson &&
           other.hashColumnsJson == this.hashColumnsJson &&
+          other.numberLocale == this.numberLocale &&
           other.updatedAt == this.updatedAt);
 }
 
@@ -9558,6 +9675,7 @@ class ImportConfigsCompanion extends UpdateCompanion<ImportConfig> {
   final Value<String> mappingsJson;
   final Value<String> formulaJson;
   final Value<String> hashColumnsJson;
+  final Value<String?> numberLocale;
   final Value<DateTime> updatedAt;
   const ImportConfigsCompanion({
     this.id = const Value.absent(),
@@ -9566,6 +9684,7 @@ class ImportConfigsCompanion extends UpdateCompanion<ImportConfig> {
     this.mappingsJson = const Value.absent(),
     this.formulaJson = const Value.absent(),
     this.hashColumnsJson = const Value.absent(),
+    this.numberLocale = const Value.absent(),
     this.updatedAt = const Value.absent(),
   });
   ImportConfigsCompanion.insert({
@@ -9575,6 +9694,7 @@ class ImportConfigsCompanion extends UpdateCompanion<ImportConfig> {
     this.mappingsJson = const Value.absent(),
     this.formulaJson = const Value.absent(),
     this.hashColumnsJson = const Value.absent(),
+    this.numberLocale = const Value.absent(),
     this.updatedAt = const Value.absent(),
   }) : accountId = Value(accountId);
   static Insertable<ImportConfig> custom({
@@ -9584,6 +9704,7 @@ class ImportConfigsCompanion extends UpdateCompanion<ImportConfig> {
     Expression<String>? mappingsJson,
     Expression<String>? formulaJson,
     Expression<String>? hashColumnsJson,
+    Expression<String>? numberLocale,
     Expression<DateTime>? updatedAt,
   }) {
     return RawValuesInsertable({
@@ -9593,6 +9714,7 @@ class ImportConfigsCompanion extends UpdateCompanion<ImportConfig> {
       if (mappingsJson != null) 'mappings_json': mappingsJson,
       if (formulaJson != null) 'formula_json': formulaJson,
       if (hashColumnsJson != null) 'hash_columns_json': hashColumnsJson,
+      if (numberLocale != null) 'number_locale': numberLocale,
       if (updatedAt != null) 'updated_at': updatedAt,
     });
   }
@@ -9604,6 +9726,7 @@ class ImportConfigsCompanion extends UpdateCompanion<ImportConfig> {
     Value<String>? mappingsJson,
     Value<String>? formulaJson,
     Value<String>? hashColumnsJson,
+    Value<String?>? numberLocale,
     Value<DateTime>? updatedAt,
   }) {
     return ImportConfigsCompanion(
@@ -9613,6 +9736,7 @@ class ImportConfigsCompanion extends UpdateCompanion<ImportConfig> {
       mappingsJson: mappingsJson ?? this.mappingsJson,
       formulaJson: formulaJson ?? this.formulaJson,
       hashColumnsJson: hashColumnsJson ?? this.hashColumnsJson,
+      numberLocale: numberLocale ?? this.numberLocale,
       updatedAt: updatedAt ?? this.updatedAt,
     );
   }
@@ -9638,6 +9762,9 @@ class ImportConfigsCompanion extends UpdateCompanion<ImportConfig> {
     if (hashColumnsJson.present) {
       map['hash_columns_json'] = Variable<String>(hashColumnsJson.value);
     }
+    if (numberLocale.present) {
+      map['number_locale'] = Variable<String>(numberLocale.value);
+    }
     if (updatedAt.present) {
       map['updated_at'] = Variable<DateTime>(updatedAt.value);
     }
@@ -9653,6 +9780,7 @@ class ImportConfigsCompanion extends UpdateCompanion<ImportConfig> {
           ..write('mappingsJson: $mappingsJson, ')
           ..write('formulaJson: $formulaJson, ')
           ..write('hashColumnsJson: $hashColumnsJson, ')
+          ..write('numberLocale: $numberLocale, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
         .toString();
@@ -12556,6 +12684,7 @@ typedef $$IntermediariesTableCreateCompanionBuilder =
       Value<int> id,
       required String name,
       Value<int> sortOrder,
+      Value<String?> defaultImportLocale,
       Value<DateTime> createdAt,
       Value<DateTime> updatedAt,
     });
@@ -12564,6 +12693,7 @@ typedef $$IntermediariesTableUpdateCompanionBuilder =
       Value<int> id,
       Value<String> name,
       Value<int> sortOrder,
+      Value<String?> defaultImportLocale,
       Value<DateTime> createdAt,
       Value<DateTime> updatedAt,
     });
@@ -12642,6 +12772,11 @@ class $$IntermediariesTableFilterComposer
 
   ColumnFilters<int> get sortOrder => $composableBuilder(
     column: $table.sortOrder,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get defaultImportLocale => $composableBuilder(
+    column: $table.defaultImportLocale,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -12730,6 +12865,11 @@ class $$IntermediariesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get defaultImportLocale => $composableBuilder(
+    column: $table.defaultImportLocale,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
     column: $table.createdAt,
     builder: (column) => ColumnOrderings(column),
@@ -12758,6 +12898,11 @@ class $$IntermediariesTableAnnotationComposer
 
   GeneratedColumn<int> get sortOrder =>
       $composableBuilder(column: $table.sortOrder, builder: (column) => column);
+
+  GeneratedColumn<String> get defaultImportLocale => $composableBuilder(
+    column: $table.defaultImportLocale,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -12849,12 +12994,14 @@ class $$IntermediariesTableTableManager
                 Value<int> id = const Value.absent(),
                 Value<String> name = const Value.absent(),
                 Value<int> sortOrder = const Value.absent(),
+                Value<String?> defaultImportLocale = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
               }) => IntermediariesCompanion(
                 id: id,
                 name: name,
                 sortOrder: sortOrder,
+                defaultImportLocale: defaultImportLocale,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
               ),
@@ -12863,12 +13010,14 @@ class $$IntermediariesTableTableManager
                 Value<int> id = const Value.absent(),
                 required String name,
                 Value<int> sortOrder = const Value.absent(),
+                Value<String?> defaultImportLocale = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
               }) => IntermediariesCompanion.insert(
                 id: id,
                 name: name,
                 sortOrder: sortOrder,
+                defaultImportLocale: defaultImportLocale,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
               ),
@@ -19751,6 +19900,7 @@ typedef $$ImportConfigsTableCreateCompanionBuilder =
       Value<String> mappingsJson,
       Value<String> formulaJson,
       Value<String> hashColumnsJson,
+      Value<String?> numberLocale,
       Value<DateTime> updatedAt,
     });
 typedef $$ImportConfigsTableUpdateCompanionBuilder =
@@ -19761,6 +19911,7 @@ typedef $$ImportConfigsTableUpdateCompanionBuilder =
       Value<String> mappingsJson,
       Value<String> formulaJson,
       Value<String> hashColumnsJson,
+      Value<String?> numberLocale,
       Value<DateTime> updatedAt,
     });
 
@@ -19823,6 +19974,11 @@ class $$ImportConfigsTableFilterComposer
 
   ColumnFilters<String> get hashColumnsJson => $composableBuilder(
     column: $table.hashColumnsJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get numberLocale => $composableBuilder(
+    column: $table.numberLocale,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -19889,6 +20045,11 @@ class $$ImportConfigsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get numberLocale => $composableBuilder(
+    column: $table.numberLocale,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
     column: $table.updatedAt,
     builder: (column) => ColumnOrderings(column),
@@ -19945,6 +20106,11 @@ class $$ImportConfigsTableAnnotationComposer
 
   GeneratedColumn<String> get hashColumnsJson => $composableBuilder(
     column: $table.hashColumnsJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get numberLocale => $composableBuilder(
+    column: $table.numberLocale,
     builder: (column) => column,
   );
 
@@ -20009,6 +20175,7 @@ class $$ImportConfigsTableTableManager
                 Value<String> mappingsJson = const Value.absent(),
                 Value<String> formulaJson = const Value.absent(),
                 Value<String> hashColumnsJson = const Value.absent(),
+                Value<String?> numberLocale = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
               }) => ImportConfigsCompanion(
                 id: id,
@@ -20017,6 +20184,7 @@ class $$ImportConfigsTableTableManager
                 mappingsJson: mappingsJson,
                 formulaJson: formulaJson,
                 hashColumnsJson: hashColumnsJson,
+                numberLocale: numberLocale,
                 updatedAt: updatedAt,
               ),
           createCompanionCallback:
@@ -20027,6 +20195,7 @@ class $$ImportConfigsTableTableManager
                 Value<String> mappingsJson = const Value.absent(),
                 Value<String> formulaJson = const Value.absent(),
                 Value<String> hashColumnsJson = const Value.absent(),
+                Value<String?> numberLocale = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
               }) => ImportConfigsCompanion.insert(
                 id: id,
@@ -20035,6 +20204,7 @@ class $$ImportConfigsTableTableManager
                 mappingsJson: mappingsJson,
                 formulaJson: formulaJson,
                 hashColumnsJson: hashColumnsJson,
+                numberLocale: numberLocale,
                 updatedAt: updatedAt,
               ),
           withReferenceMapper: (p0) => p0

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -2983,9 +2983,9 @@ class $AssetsTable extends Assets with TableInfo<$AssetsTable, Asset> {
   late final GeneratedColumn<int> intermediaryId = GeneratedColumn<int>(
     'intermediary_id',
     aliasedName,
-    true,
+    false,
     type: DriftSqlType.int,
-    requiredDuringInsert: false,
+    requiredDuringInsert: true,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
       'REFERENCES intermediaries (id)',
     ),
@@ -3243,6 +3243,8 @@ class $AssetsTable extends Assets with TableInfo<$AssetsTable, Asset> {
           _intermediaryIdMeta,
         ),
       );
+    } else if (isInserting) {
+      context.missing(_intermediaryIdMeta);
     }
     if (data.containsKey('asset_group')) {
       context.handle(
@@ -3386,7 +3388,7 @@ class $AssetsTable extends Assets with TableInfo<$AssetsTable, Asset> {
       intermediaryId: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}intermediary_id'],
-      ),
+      )!,
       assetGroup: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}asset_group'],
@@ -3483,7 +3485,7 @@ class Asset extends DataClass implements Insertable<Asset> {
   final AssetType assetType;
   final InstrumentType instrumentType;
   final AssetClass assetClass;
-  final int? intermediaryId;
+  final int intermediaryId;
   final String assetGroup;
   final String currency;
   final String? exchange;
@@ -3508,7 +3510,7 @@ class Asset extends DataClass implements Insertable<Asset> {
     required this.assetType,
     required this.instrumentType,
     required this.assetClass,
-    this.intermediaryId,
+    required this.intermediaryId,
     required this.assetGroup,
     required this.currency,
     this.exchange,
@@ -3552,9 +3554,7 @@ class Asset extends DataClass implements Insertable<Asset> {
         $AssetsTable.$converterassetClass.toSql(assetClass),
       );
     }
-    if (!nullToAbsent || intermediaryId != null) {
-      map['intermediary_id'] = Variable<int>(intermediaryId);
-    }
+    map['intermediary_id'] = Variable<int>(intermediaryId);
     map['asset_group'] = Variable<String>(assetGroup);
     map['currency'] = Variable<String>(currency);
     if (!nullToAbsent || exchange != null) {
@@ -3605,9 +3605,7 @@ class Asset extends DataClass implements Insertable<Asset> {
       assetType: Value(assetType),
       instrumentType: Value(instrumentType),
       assetClass: Value(assetClass),
-      intermediaryId: intermediaryId == null && nullToAbsent
-          ? const Value.absent()
-          : Value(intermediaryId),
+      intermediaryId: Value(intermediaryId),
       assetGroup: Value(assetGroup),
       currency: Value(currency),
       exchange: exchange == null && nullToAbsent
@@ -3660,7 +3658,7 @@ class Asset extends DataClass implements Insertable<Asset> {
       assetClass: $AssetsTable.$converterassetClass.fromJson(
         serializer.fromJson<String>(json['assetClass']),
       ),
-      intermediaryId: serializer.fromJson<int?>(json['intermediaryId']),
+      intermediaryId: serializer.fromJson<int>(json['intermediaryId']),
       assetGroup: serializer.fromJson<String>(json['assetGroup']),
       currency: serializer.fromJson<String>(json['currency']),
       exchange: serializer.fromJson<String?>(json['exchange']),
@@ -3698,7 +3696,7 @@ class Asset extends DataClass implements Insertable<Asset> {
       'assetClass': serializer.toJson<String>(
         $AssetsTable.$converterassetClass.toJson(assetClass),
       ),
-      'intermediaryId': serializer.toJson<int?>(intermediaryId),
+      'intermediaryId': serializer.toJson<int>(intermediaryId),
       'assetGroup': serializer.toJson<String>(assetGroup),
       'currency': serializer.toJson<String>(currency),
       'exchange': serializer.toJson<String?>(exchange),
@@ -3728,7 +3726,7 @@ class Asset extends DataClass implements Insertable<Asset> {
     AssetType? assetType,
     InstrumentType? instrumentType,
     AssetClass? assetClass,
-    Value<int?> intermediaryId = const Value.absent(),
+    int? intermediaryId,
     String? assetGroup,
     String? currency,
     Value<String?> exchange = const Value.absent(),
@@ -3753,9 +3751,7 @@ class Asset extends DataClass implements Insertable<Asset> {
     assetType: assetType ?? this.assetType,
     instrumentType: instrumentType ?? this.instrumentType,
     assetClass: assetClass ?? this.assetClass,
-    intermediaryId: intermediaryId.present
-        ? intermediaryId.value
-        : this.intermediaryId,
+    intermediaryId: intermediaryId ?? this.intermediaryId,
     assetGroup: assetGroup ?? this.assetGroup,
     currency: currency ?? this.currency,
     exchange: exchange.present ? exchange.value : this.exchange,
@@ -3912,7 +3908,7 @@ class AssetsCompanion extends UpdateCompanion<Asset> {
   final Value<AssetType> assetType;
   final Value<InstrumentType> instrumentType;
   final Value<AssetClass> assetClass;
-  final Value<int?> intermediaryId;
+  final Value<int> intermediaryId;
   final Value<String> assetGroup;
   final Value<String> currency;
   final Value<String?> exchange;
@@ -3963,7 +3959,7 @@ class AssetsCompanion extends UpdateCompanion<Asset> {
     required AssetType assetType,
     this.instrumentType = const Value.absent(),
     this.assetClass = const Value.absent(),
-    this.intermediaryId = const Value.absent(),
+    required int intermediaryId,
     this.assetGroup = const Value.absent(),
     this.currency = const Value.absent(),
     this.exchange = const Value.absent(),
@@ -3982,6 +3978,7 @@ class AssetsCompanion extends UpdateCompanion<Asset> {
     this.updatedAt = const Value.absent(),
   }) : name = Value(name),
        assetType = Value(assetType),
+       intermediaryId = Value(intermediaryId),
        valuationMethod = Value(valuationMethod);
   static Insertable<Asset> custom({
     Expression<int>? id,
@@ -4045,7 +4042,7 @@ class AssetsCompanion extends UpdateCompanion<Asset> {
     Value<AssetType>? assetType,
     Value<InstrumentType>? instrumentType,
     Value<AssetClass>? assetClass,
-    Value<int?>? intermediaryId,
+    Value<int>? intermediaryId,
     Value<String>? assetGroup,
     Value<String>? currency,
     Value<String?>? exchange,
@@ -15388,7 +15385,7 @@ typedef $$AssetsTableCreateCompanionBuilder =
       required AssetType assetType,
       Value<InstrumentType> instrumentType,
       Value<AssetClass> assetClass,
-      Value<int?> intermediaryId,
+      required int intermediaryId,
       Value<String> assetGroup,
       Value<String> currency,
       Value<String?> exchange,
@@ -15415,7 +15412,7 @@ typedef $$AssetsTableUpdateCompanionBuilder =
       Value<AssetType> assetType,
       Value<InstrumentType> instrumentType,
       Value<AssetClass> assetClass,
-      Value<int?> intermediaryId,
+      Value<int> intermediaryId,
       Value<String> assetGroup,
       Value<String> currency,
       Value<String?> exchange,
@@ -15443,9 +15440,9 @@ final class $$AssetsTableReferences
         $_aliasNameGenerator(db.assets.intermediaryId, db.intermediaries.id),
       );
 
-  $$IntermediariesTableProcessedTableManager? get intermediaryId {
-    final $_column = $_itemColumn<int>('intermediary_id');
-    if ($_column == null) return null;
+  $$IntermediariesTableProcessedTableManager get intermediaryId {
+    final $_column = $_itemColumn<int>('intermediary_id')!;
+
     final manager = $$IntermediariesTableTableManager(
       $_db,
       $_db.intermediaries,
@@ -16195,7 +16192,7 @@ class $$AssetsTableTableManager
                 Value<AssetType> assetType = const Value.absent(),
                 Value<InstrumentType> instrumentType = const Value.absent(),
                 Value<AssetClass> assetClass = const Value.absent(),
-                Value<int?> intermediaryId = const Value.absent(),
+                Value<int> intermediaryId = const Value.absent(),
                 Value<String> assetGroup = const Value.absent(),
                 Value<String> currency = const Value.absent(),
                 Value<String?> exchange = const Value.absent(),
@@ -16247,7 +16244,7 @@ class $$AssetsTableTableManager
                 required AssetType assetType,
                 Value<InstrumentType> instrumentType = const Value.absent(),
                 Value<AssetClass> assetClass = const Value.absent(),
-                Value<int?> intermediaryId = const Value.absent(),
+                required int intermediaryId,
                 Value<String> assetGroup = const Value.absent(),
                 Value<String> currency = const Value.absent(),
                 Value<String?> exchange = const Value.absent(),

--- a/lib/database/tables.dart
+++ b/lib/database/tables.dart
@@ -125,6 +125,10 @@ class Intermediaries extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get name => text().withLength(min: 1, max: 100)();
   IntColumn get sortOrder => integer().withDefault(const Constant(0))();
+  /// Number-format locale used to parse asset-event imports under this
+  /// intermediary (e.g. 'it_IT', 'en_US'). NULL means "Auto — use the
+  /// app locale".
+  TextColumn get defaultImportLocale => text().nullable()();
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
   DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
 }
@@ -361,6 +365,9 @@ class ImportConfigs extends Table {
   TextColumn get mappingsJson => text().withDefault(const Constant('{}'))(); // JSON: {targetField: sourceColumn}
   TextColumn get formulaJson => text().withDefault(const Constant('[]'))(); // JSON: [{operator, sourceColumn}]
   TextColumn get hashColumnsJson => text().withDefault(const Constant('[]'))(); // JSON: [col1, col2, ...]
+  /// Number-format locale used to parse this account's import files
+  /// (e.g. 'it_IT', 'en_US'). NULL means "Auto — use the app locale".
+  TextColumn get numberLocale => text().nullable()();
   DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
 }
 

--- a/lib/database/tables.dart
+++ b/lib/database/tables.dart
@@ -190,7 +190,10 @@ class Assets extends Table {
   TextColumn get assetType => textEnum<AssetType>()();
   TextColumn get instrumentType => textEnum<InstrumentType>().withDefault(Constant(InstrumentType.etf.name))();
   TextColumn get assetClass => textEnum<AssetClass>().withDefault(Constant(AssetClass.equity.name))();
-  IntColumn get intermediaryId => integer().nullable().references(Intermediaries, #id)();
+  // Every asset must belong to an intermediary (broker/custodian). Unassigned
+  // was removed in schema v29 — migration backfills NULL to a "Default"
+  // intermediary created on upgrade.
+  IntColumn get intermediaryId => integer().references(Intermediaries, #id)();
   TextColumn get assetGroup => text().withDefault(const Constant(''))();
   TextColumn get currency => text().withLength(min: 3, max: 3).withDefault(const Constant('EUR'))();
   TextColumn get exchange => text().nullable()();

--- a/lib/l10n/app_strings.dart
+++ b/lib/l10n/app_strings.dart
@@ -701,6 +701,7 @@ class AppStrings {
   String errorParsingClipboard(Object e) => _it ? 'Errore nel parsificare gli appunti: $e' : 'Error parsing clipboard: $e';
   String get selectAccount         => _it ? 'Seleziona conto'          : 'Select Account';
   String get importSummary         => _it ? 'Riepilogo importazione'   : 'Import Summary';
+  String get numberFormatLabel     => _it ? 'Formato numeri'           : 'Number format';
   String sourceFile(String name)   => _it ? 'Origine: $name'           : 'Source: $name';
   String get clipboard             => _it ? 'Appunti'                  : 'Clipboard';
   String rowCount(int n)           => _it ? 'Righe: $n'                : 'Rows: $n';

--- a/lib/l10n/app_strings.dart
+++ b/lib/l10n/app_strings.dart
@@ -890,6 +890,7 @@ class AppStrings {
       : 'Delete "$name"? Accounts and assets will be moved to "Unassigned".';
   String get intermediaryMoved     => _it ? 'Spostato con successo'     : 'Moved successfully';
   String get selectIntermediary    => _it ? 'Seleziona intermediario'   : 'Select Intermediary';
+  String get selectIntermediaryEmpty => _it ? 'Nessun intermediario. Creane uno per procedere.' : 'No intermediary yet. Create one to continue.';
   String get close                 => _it ? 'Chiudi'                    : 'Close';
 
   // ── Multi-select ─────────────────────────────────────────

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -167,7 +167,7 @@ class _AppShellState extends ConsumerState<AppShell> {
         // Check for legacy DB at old Documents path and migrate if found
         final migrated = await _migrateLegacyDb(dbFile);
         if (!migrated) {
-          _log.info('No DB file found, showing landing page');
+          _log.info('No DB file ${dbFile.path} found, showing landing page');
           if (mounted) setState(() => _showLanding = true);
           return;
         }

--- a/lib/services/asset_service.dart
+++ b/lib/services/asset_service.dart
@@ -45,6 +45,7 @@ class AssetService {
 
   Future<int> create({
     required String name,
+    required int intermediaryId,
     String? ticker,
     String? isin,
     String? exchange,
@@ -55,11 +56,13 @@ class AssetService {
     AssetClass? assetClass,
   }) {
     _log.info('create: name=$name, ticker=$ticker, isin=$isin, exchange=$exchange, '
-        'valuation=${valuationMethod.name}, instrument=${instrumentType?.name}, class=${assetClass?.name}');
+        'intermediary=$intermediaryId, valuation=${valuationMethod.name}, '
+        'instrument=${instrumentType?.name}, class=${assetClass?.name}');
     return _db.into(_db.assets).insert(AssetsCompanion.insert(
       name: name,
       assetType: AssetType.stockEtf,
       valuationMethod: valuationMethod,
+      intermediaryId: intermediaryId,
       ticker: Value(ticker),
       isin: Value(isin),
       exchange: Value(exchange),

--- a/lib/services/demo_db_service.dart
+++ b/lib/services/demo_db_service.dart
@@ -151,6 +151,10 @@ class DemoDbService {
   // ── Assets (fictional, anonymized) ──
 
   static Future<void> _insertAssets(AppDatabase db) async {
+    // Every asset needs an intermediary since schema v29; create a demo one.
+    final intermediaryId = await db.into(db.intermediaries).insert(
+      IntermediariesCompanion.insert(name: 'Demo Broker'),
+    );
     final assets = [
       ('VWCE', 'Vanguard FTSE All-World', AssetType.stockEtf, InstrumentType.etf, AssetClass.equity, 'EUR', 'MIL', 'VWCE.MI', 'IE00BK5BQT80', 'global'),
       ('AGGH', 'iShares Core Global Agg Bond', AssetType.bondEtf, InstrumentType.etf, AssetClass.fixedIncome, 'EUR', 'MIL', 'AGGH.MI', 'IE00BDBRDM35', 'bonds'),
@@ -174,6 +178,7 @@ class DemoDbService {
         yahooTicker: Value(yahoo),
         valuationMethod: ValuationMethod.marketPrice,
         sortOrder: Value(i + 1),
+        intermediaryId: intermediaryId,
       ));
     }
   }

--- a/lib/services/import_service.dart
+++ b/lib/services/import_service.dart
@@ -423,9 +423,10 @@ class ImportService {
     /// If provided, fills missing exchange rates from historical data after import.
     ExchangeRateService? rateService,
     required String baseCurrency,
-    /// If set, new assets are assigned to this intermediary and deletion
-    /// is scoped to ALL assets under this intermediary.
-    int? intermediaryId,
+    /// New assets are assigned to this intermediary; deletion is scoped to
+    /// ALL assets under this intermediary. Required — unassigned was removed
+    /// in schema v29.
+    required int intermediaryId,
   }) async {
     _log.info('importAssetEventsGrouped: ${preview.totalRows} rows, ${mappings.length} mappings');
     final mappingByField = {for (final m in mappings) m.targetField: m};
@@ -475,11 +476,15 @@ class ImportService {
 
     _log.info('importAssetEventsGrouped: found ${isinToRows.length} unique ISINs');
 
-    // Find or create asset for each ISIN
+    // Find or create asset for each ISIN. Scope the lookup to this
+    // intermediary so the same ISIN held at two brokers produces two
+    // independent asset rows (one per broker, each with its own events).
     final assetsByIsin = <String, int>{};
     final existingByIsin = <String, int>{};
     final existingRows = await _db.customSelect(
-      "SELECT id, isin FROM assets WHERE isin IS NOT NULL AND isin != ''",
+      "SELECT id, isin FROM assets WHERE isin IS NOT NULL AND isin != '' "
+      "AND intermediary_id = ?",
+      variables: [Variable.withInt(intermediaryId)],
       readsFrom: {_db.assets},
     ).get();
     for (final row in existingRows) {
@@ -536,7 +541,7 @@ class ImportService {
           isin: Value(isin),
           currency: Value(currency),
           exchange: Value(exchange),
-          intermediaryId: Value(intermediaryId),
+          intermediaryId: intermediaryId,
         ));
         assetsByIsin[isin] = assetId;
         _log.info('importAssetEventsGrouped: created asset id=$assetId for ISIN=$isin, name=$name, ticker=$ticker, exchange=$exchange');
@@ -672,56 +677,28 @@ class ImportService {
     }
 
     if (isSpot) {
-      // Spot import: wipe ALL events for the target scope (no date filter)
-      if (intermediaryId != null) {
-        totalDeleted = await _db.customUpdate(
-          'DELETE FROM asset_events WHERE asset_id IN '
-          '(SELECT id FROM assets WHERE intermediary_id = ?)',
-          variables: [Variable.withInt(intermediaryId)],
-          updates: {_db.assetEvents},
-        );
-        _log.info('importAssetEventsGrouped: spot wipe intermediary $intermediaryId - deleted $totalDeleted events');
-      } else {
-        for (final assetId in byAsset.keys) {
-          final deleted = await _db.customUpdate(
-            'DELETE FROM asset_events WHERE asset_id IN '
-            '(SELECT id FROM assets WHERE intermediary_id IS NULL AND id = ?)',
-            variables: [Variable.withInt(assetId)],
-            updates: {_db.assetEvents},
-          );
-          totalDeleted += deleted;
-          _log.fine('importAssetEventsGrouped: spot wipe unassigned asset $assetId - deleted $deleted events');
-        }
-      }
+      // Spot import: every asset belongs to one intermediary, so the wipe
+      // scope is the full set of events under that intermediary.
+      totalDeleted = await _db.customUpdate(
+        'DELETE FROM asset_events WHERE asset_id IN '
+        '(SELECT id FROM assets WHERE intermediary_id = ?)',
+        variables: [Variable.withInt(intermediaryId)],
+        updates: {_db.assetEvents},
+      );
+      _log.info('importAssetEventsGrouped: spot wipe intermediary $intermediaryId - deleted $totalDeleted events');
     } else {
-      // Transaction import: date-based wipe-and-replace
+      // Transaction import: date-based wipe-and-replace, scoped to the
+      // intermediary's assets.
       final globalOldest = companions.map((c) => c.date.value).reduce((a, b) => a.isBefore(b) ? a : b);
       final globalCutoff = DateTime(globalOldest.year, globalOldest.month, globalOldest.day);
       final cutoffEpoch = globalCutoff.millisecondsSinceEpoch ~/ 1000;
-
-      if (intermediaryId != null) {
-        totalDeleted = await _db.customUpdate(
-          'DELETE FROM asset_events WHERE asset_id IN '
-          '(SELECT id FROM assets WHERE intermediary_id = ?) AND date >= ?',
-          variables: [Variable.withInt(intermediaryId), Variable.withInt(cutoffEpoch)],
-          updates: {_db.assetEvents},
-        );
-        _log.info('importAssetEventsGrouped: intermediary $intermediaryId - deleted $totalDeleted events from ${formatYmd(globalCutoff)}');
-      } else {
-        for (final entry in byAsset.entries) {
-          final assetId = entry.key;
-          final events = entry.value;
-          final oldestDate = events.map((e) => e.date.value).reduce((a, b) => a.isBefore(b) ? a : b);
-          final cutoff = DateTime(oldestDate.year, oldestDate.month, oldestDate.day);
-          final deleted = await _db.customUpdate(
-            'DELETE FROM asset_events WHERE asset_id = ? AND date >= ?',
-            variables: [Variable.withInt(assetId), Variable.withInt(cutoff.millisecondsSinceEpoch ~/ 1000)],
-            updates: {_db.assetEvents},
-          );
-          totalDeleted += deleted;
-          _log.fine('importAssetEventsGrouped: asset $assetId - deleted $deleted events from ${formatYmd(cutoff)}');
-        }
-      }
+      totalDeleted = await _db.customUpdate(
+        'DELETE FROM asset_events WHERE asset_id IN '
+        '(SELECT id FROM assets WHERE intermediary_id = ?) AND date >= ?',
+        variables: [Variable.withInt(intermediaryId), Variable.withInt(cutoffEpoch)],
+        updates: {_db.assetEvents},
+      );
+      _log.info('importAssetEventsGrouped: intermediary $intermediaryId - deleted $totalDeleted events from ${formatYmd(globalCutoff)}');
     }
 
     _log.info('importAssetEventsGrouped: batch-inserting ${companions.length} events (deleted $totalDeleted old)');

--- a/lib/services/import_service.dart
+++ b/lib/services/import_service.dart
@@ -156,6 +156,12 @@ class ImportService {
   final AppDatabase _db;
   final FileParserService _parser = FileParserService();
 
+  /// Locale used for the current import call. Set by each public import
+  /// method before any number parsing happens, then read by `_parseAmount`
+  /// and `_tryParseAmount`. Defaults to en_US for safety.
+  // ignore: prefer_final_fields  // mutated per import call
+  String _activeLocale = 'en_US';
+
   ImportService(this._db);
 
   // ──────────────────────────────────────────────
@@ -233,8 +239,20 @@ class ImportService {
     String balanceMode = 'cumulative',
     String? balanceFilterColumn,
     Set<String>? balanceFilterInclude,
+    /// User's per-import locale choice from the wizard. Persisted to
+    /// `ImportConfigs.numberLocale` for this account when non-null.
+    /// NULL means "Auto — fall back to the saved value or [appLocale]".
+    String? numberLocaleOverride,
+    /// App's configured locale (e.g. `it_IT`). Used as the final fallback
+    /// when no per-source override or saved value exists.
+    String? appLocale,
   }) async {
-    _log.info('importTransactions: accountId=$accountId, ${preview.totalRows} rows, ${mappings.length} mappings');
+    await _setLocaleForAccount(
+      accountId: accountId,
+      override: numberLocaleOverride,
+      appLocale: appLocale,
+    );
+    _log.info('importTransactions: accountId=$accountId, ${preview.totalRows} rows, ${mappings.length} mappings, locale=$_activeLocale');
     final mappingByField = {for (final m in mappings) m.targetField: m};
     final dateMapping = mappingByField['date'];
     final amountMapping = mappingByField['amount'];
@@ -427,8 +445,19 @@ class ImportService {
     /// ALL assets under this intermediary. Required — unassigned was removed
     /// in schema v29.
     required int intermediaryId,
+    /// User's per-import locale choice from the wizard. Persisted to
+    /// `Intermediaries.defaultImportLocale` for this intermediary when
+    /// non-null. NULL means "Auto — fall back to saved or [appLocale]".
+    String? numberLocaleOverride,
+    /// App's configured locale (e.g. `it_IT`). Final fallback.
+    String? appLocale,
   }) async {
-    _log.info('importAssetEventsGrouped: ${preview.totalRows} rows, ${mappings.length} mappings');
+    await _setLocaleForIntermediary(
+      intermediaryId: intermediaryId,
+      override: numberLocaleOverride,
+      appLocale: appLocale,
+    );
+    _log.info('importAssetEventsGrouped: ${preview.totalRows} rows, ${mappings.length} mappings, locale=$_activeLocale');
     final mappingByField = {for (final m in mappings) m.targetField: m};
     final dateMapping = mappingByField['date'];
     final amountMapping = mappingByField['amount'];
@@ -744,8 +773,17 @@ class ImportService {
     required List<ColumnMapping> mappings,
     required String defaultCurrency,
     void Function(int processed, int total)? onProgress,
+    /// User's per-import locale choice. Persisted to the
+    /// `IMPORT_INCOME_LOCALE` AppConfigs key when non-null.
+    String? numberLocaleOverride,
+    /// App's configured locale (e.g. `it_IT`). Final fallback.
+    String? appLocale,
   }) async {
-    _log.info('importIncomes: ${preview.totalRows} rows, ${mappings.length} mappings, defaultCurrency=$defaultCurrency');
+    await _setLocaleForIncome(
+      override: numberLocaleOverride,
+      appLocale: appLocale,
+    );
+    _log.info('importIncomes: ${preview.totalRows} rows, ${mappings.length} mappings, defaultCurrency=$defaultCurrency, locale=$_activeLocale');
     final mappingByField = {for (final m in mappings) m.targetField: m};
     final dateMapping = mappingByField['date'];
     final amountMapping = mappingByField['amount'];
@@ -846,8 +884,17 @@ class ImportService {
     String balanceMode = 'cumulative',
     String? balanceFilterColumn,
     Set<String>? balanceFilterInclude,
+    /// Locale used for parsing during preview only — NOT persisted.
+    String? numberLocale,
+    String? appLocale,
   }) async {
-    _log.info('previewTransactionImport: accountId=$accountId, ${preview.totalRows} rows');
+    final saved = numberLocale ??
+        (await (_db.select(_db.importConfigs)
+                  ..where((c) => c.accountId.equals(accountId)))
+                .getSingleOrNull())
+            ?.numberLocale;
+    _activeLocale = amt.resolveImportLocale(saved: saved, appLocale: appLocale);
+    _log.info('previewTransactionImport: accountId=$accountId, ${preview.totalRows} rows, locale=$_activeLocale');
     final mappingByField = {for (final m in mappings) m.targetField: m};
     final dateMapping = mappingByField['date'];
     final amountMapping = mappingByField['amount'];
@@ -983,8 +1030,16 @@ class ImportService {
     Set<String>? sellValues,
     Set<String>? excludedIsins,
     Map<String, IsinExchangeOption>? selectedExchanges,
+    /// Locale used for parsing during preview only — NOT persisted.
+    /// Caller resolves to whatever the wizard selection is right now.
+    String? numberLocale,
+    String? appLocale,
   }) async {
-    _log.info('previewAssetEventImport: ${preview.totalRows} rows');
+    _activeLocale = amt.resolveImportLocale(
+      saved: numberLocale,
+      appLocale: appLocale,
+    );
+    _log.info('previewAssetEventImport: ${preview.totalRows} rows, locale=$_activeLocale');
     final mappingByField = {for (final m in mappings) m.targetField: m};
     final isinMapping = mappingByField['isin'];
 
@@ -1090,8 +1145,107 @@ class ImportService {
   /// Parse a date string. Delegates to shared [date_parse.parseDate].
   DateTime _parseDate(String s) => date_parse.parseDate(s);
 
-  double _parseAmount(String s) => amt.parseAmount(s);
-  double? _tryParseAmount(String? s) => amt.tryParseAmount(s);
+  double _parseAmount(String s) => amt.parseAmount(s, locale: _activeLocale);
+  double? _tryParseAmount(String? s) => amt.tryParseAmount(s, locale: _activeLocale);
+
+  // ──────────────────────────────────────────────
+  // Number-locale persistence (per-flow)
+  // ──────────────────────────────────────────────
+
+  /// Resolve the effective locale for a transaction import on [accountId]:
+  /// 1. wizard `override` (also persists it to ImportConfigs)
+  /// 2. previously-saved `ImportConfigs.numberLocale[accountId]`
+  /// 3. `appLocale`
+  /// 4. `en_US` (final fallback in [amt.resolveImportLocale])
+  Future<void> _setLocaleForAccount({
+    required int accountId,
+    required String? override,
+    required String? appLocale,
+  }) async {
+    final saved = override ??
+        (await (_db.select(_db.importConfigs)
+                  ..where((c) => c.accountId.equals(accountId)))
+                .getSingleOrNull())
+            ?.numberLocale;
+    _activeLocale = amt.resolveImportLocale(saved: saved, appLocale: appLocale);
+
+    if (override != null) {
+      // Upsert into ImportConfigs. If no row exists yet, create one with
+      // sensible defaults so future opens of the wizard show the choice.
+      final existing = await (_db.select(_db.importConfigs)
+            ..where((c) => c.accountId.equals(accountId)))
+          .getSingleOrNull();
+      if (existing == null) {
+        await _db.into(_db.importConfigs).insert(ImportConfigsCompanion.insert(
+              accountId: accountId,
+              numberLocale: Value(override),
+            ));
+      } else {
+        await (_db.update(_db.importConfigs)
+              ..where((c) => c.accountId.equals(accountId)))
+            .write(ImportConfigsCompanion(
+          numberLocale: Value(override),
+          updatedAt: Value(DateTime.now()),
+        ));
+      }
+    }
+  }
+
+  /// Resolve the effective locale for an asset-event import on
+  /// [intermediaryId]. Same priority order as [_setLocaleForAccount];
+  /// persistence target is `Intermediaries.defaultImportLocale`.
+  Future<void> _setLocaleForIntermediary({
+    required int intermediaryId,
+    required String? override,
+    required String? appLocale,
+  }) async {
+    final saved = override ??
+        (await (_db.select(_db.intermediaries)
+                  ..where((i) => i.id.equals(intermediaryId)))
+                .getSingleOrNull())
+            ?.defaultImportLocale;
+    _activeLocale = amt.resolveImportLocale(saved: saved, appLocale: appLocale);
+
+    if (override != null) {
+      await (_db.update(_db.intermediaries)
+            ..where((i) => i.id.equals(intermediaryId)))
+          .write(IntermediariesCompanion(
+        defaultImportLocale: Value(override),
+        updatedAt: Value(DateTime.now()),
+      ));
+    }
+  }
+
+  static const _incomeLocaleConfigKey = 'IMPORT_INCOME_LOCALE';
+
+  /// Resolve the effective locale for an income import. Persistence target
+  /// is the `IMPORT_INCOME_LOCALE` AppConfigs row (single global value;
+  /// income imports don't have a per-source key today).
+  Future<void> _setLocaleForIncome({
+    required String? override,
+    required String? appLocale,
+  }) async {
+    String? saved = override;
+    if (saved == null) {
+      final row = await _db.customSelect(
+        'SELECT value FROM app_configs WHERE key = ?',
+        variables: [Variable.withString(_incomeLocaleConfigKey)],
+      ).getSingleOrNull();
+      final v = row?.read<String?>('value');
+      if (v != null && v.isNotEmpty) saved = v;
+    }
+    _activeLocale = amt.resolveImportLocale(saved: saved, appLocale: appLocale);
+
+    if (override != null) {
+      await _db.into(_db.appConfigs).insertOnConflictUpdate(
+            AppConfigsCompanion.insert(
+              key: _incomeLocaleConfigKey,
+              value: override,
+              description: const Value('Number-format locale for income imports'),
+            ),
+          );
+    }
+  }
 
   EventType _parseEventType(String s, {Set<String>? buyValues, Set<String>? sellValues}) {
     final normalized = s.trim().toUpperCase().replaceAll(' ', '_');

--- a/lib/services/intermediary_service.dart
+++ b/lib/services/intermediary_service.dart
@@ -31,19 +31,23 @@ class IntermediaryService {
 
   Future<void> delete(int id) async {
     _log.info('delete: id=$id');
-    // Unlink accounts and assets before deleting
+    // Assets need an intermediary since schema v29 — refuse to delete if any
+    // are still attached. Caller should prompt the user to move them first.
+    final assetCount = (await _db.customSelect(
+      'SELECT COUNT(*) AS c FROM assets WHERE intermediary_id = ?',
+      variables: [Variable.withInt(id)],
+    ).getSingle()).read<int>('c');
+    if (assetCount > 0) {
+      throw StateError('intermediary_has_assets:$assetCount');
+    }
+    // Accounts are still nullable — unlink them.
     await _db.customUpdate(
       'UPDATE accounts SET intermediary_id = NULL WHERE intermediary_id = ?',
       variables: [Variable.withInt(id)],
       updates: {_db.accounts},
     );
-    await _db.customUpdate(
-      'UPDATE assets SET intermediary_id = NULL WHERE intermediary_id = ?',
-      variables: [Variable.withInt(id)],
-      updates: {_db.assets},
-    );
     await (_db.delete(_db.intermediaries)..where((i) => i.id.equals(id))).go();
-    _log.info('delete: id=$id - unlinked accounts/assets and removed');
+    _log.info('delete: id=$id - removed (accounts unlinked)');
   }
 
   Future<void> reorder(List<int> orderedIds) async {
@@ -65,7 +69,7 @@ class IntermediaryService {
         .write(AccountsCompanion(intermediaryId: Value(intermediaryId)));
   }
 
-  Future<void> moveAsset(int assetId, int? intermediaryId) async {
+  Future<void> moveAsset(int assetId, int intermediaryId) async {
     _log.info('moveAsset: assetId=$assetId -> intermediaryId=$intermediaryId');
     await (_db.update(_db.assets)..where((a) => a.id.equals(assetId)))
         .write(AssetsCompanion(intermediaryId: Value(intermediaryId)));

--- a/lib/services/transaction_service.dart
+++ b/lib/services/transaction_service.dart
@@ -101,7 +101,12 @@ class TransactionService {
     final mappings = jsonDecode(config.mappingsJson) as Map<String, dynamic>;
     final mode = (mappings['__balanceMode'] as String?) ?? 'none';
     if (mode == 'none') return;
-    await recalculateBalances(accountId, balanceMode: mode, savedMappings: mappings);
+    await recalculateBalances(
+      accountId,
+      balanceMode: mode,
+      savedMappings: mappings,
+      numberLocale: config.numberLocale,
+    );
   }
 
   /// Batch-update balanceAfter for multiple transactions in a single DB transaction.
@@ -131,8 +136,10 @@ class TransactionService {
     int accountId, {
     required String balanceMode,
     Map<String, dynamic> savedMappings = const {},
+    String? numberLocale,
   }) async {
     if (balanceMode == 'none') return 0;
+    final locale = numberLocale ?? 'en_US';
 
     final txs = await getByAccount(accountId);
     if (txs.isEmpty) return 0;
@@ -165,7 +172,7 @@ class TransactionService {
         if (balanceColumn != null && tx.rawMetadata != null) {
           final meta = jsonDecode(tx.rawMetadata!) as Map<String, dynamic>;
           final raw = meta[balanceColumn]?.toString() ?? '';
-          newBalance = amt.tryParseAmount(raw);
+          newBalance = amt.tryParseAmount(raw, locale: locale);
         }
       } else if (balanceMode == 'cumulative') {
         balanceCents += toCents(tx.amount);

--- a/lib/ui/screens/assets_screen.dart
+++ b/lib/ui/screens/assets_screen.dart
@@ -51,18 +51,16 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
     return ListenableBuilder(
       listenable: _selection,
       builder: (lbCtx, _) {
-        // Build the id list in rendered order: grouped by intermediary, then
-        // unassigned last. This matches what _buildGroup actually displays
-        // and is what range-select on long-press needs.
+        // Build the id list in rendered order: grouped by intermediary.
+        // Every asset must have an intermediary (schema v29 invariant).
         final assets = assetsAsync.value ?? const <Asset>[];
         final intermediariesNow = intermediariesAsync.value ?? const <Intermediary>[];
-        final grouping = <int?, List<int>>{};
+        final grouping = <int, List<int>>{};
         for (final a in assets) {
           (grouping[a.intermediaryId] ??= []).add(a.id);
         }
         final allAssetIds = <int>[
           for (final i in intermediariesNow) ...?grouping[i.id],
-          ...?grouping[null],
         ];
         _selection.setOrderedIds(allAssetIds);
         return Scaffold(
@@ -93,25 +91,19 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
           final stats = statsAsync.value ?? {};
           final intermediaries = intermediariesAsync.value ?? [];
 
-          final grouped = <int?, List<Asset>>{};
+          final grouped = <int, List<Asset>>{};
           for (final asset in assets) {
             (grouped[asset.intermediaryId] ??= []).add(asset);
           }
 
-          final groupOrder = <int?>[
-            ...intermediaries.map((i) => i.id),
-            null,
-          ];
-
           return ListView(
             padding: const EdgeInsets.only(bottom: 80),
             children: [
-              for (final groupId in groupOrder)
-                if (grouped[groupId]?.isNotEmpty ?? false)
+              for (final i in intermediaries)
+                if (grouped[i.id]?.isNotEmpty ?? false)
                   _buildGroup(
-                    context, s, groupId,
-                    groupId == null ? null : intermediaries.firstWhere((i) => i.id == groupId),
-                    grouped[groupId] ?? [],
+                    context, s, i.id, i,
+                    grouped[i.id] ?? [],
                     stats, convertedStats, marketValues, baseCurrency, locale,
                     intermediaries,
                   ),
@@ -157,8 +149,8 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
   Widget _buildGroup(
     BuildContext context,
     AppStrings s,
-    int? groupId,
-    Intermediary? intermediary,
+    int groupId,
+    Intermediary intermediary,
     List<Asset> assets,
     Map<int, AssetStats> stats,
     Map<int, double?> convertedStats,
@@ -167,8 +159,6 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
     String locale,
     List<Intermediary> intermediaries,
   ) {
-    final title = intermediary?.name ?? s.unassigned;
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -176,15 +166,11 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Row(
             children: [
-              Icon(
-                intermediary != null ? Icons.business : Icons.folder_open,
-                size: 18,
-                color: Colors.grey,
-              ),
+              const Icon(Icons.business, size: 18, color: Colors.grey),
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  '$title (${assets.length})',
+                  '${intermediary.name} (${assets.length})',
                   style: Theme.of(context).textTheme.titleSmall?.copyWith(
                     fontWeight: FontWeight.w600,
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
@@ -300,7 +286,7 @@ class _AssetsScreenState extends ConsumerState<AssetsScreen> {
                   children: [
                     Expanded(
                       child: intermediaries.isEmpty
-                          ? Center(child: Text(s.unassigned, style: TextStyle(color: Colors.grey)))
+                          ? Center(child: Text(s.selectIntermediaryEmpty, style: TextStyle(color: Colors.grey)))
                           : ReorderableListView.builder(
                               shrinkWrap: true,
                               buildDefaultDragHandles: false,
@@ -379,7 +365,7 @@ class _AssetTile extends StatelessWidget {
   final VoidCallback onTap;
   final AppStrings strings;
   final List<Intermediary> intermediaries;
-  final void Function(int? newIntermediaryId) onMove;
+  final void Function(int newIntermediaryId) onMove;
 
   const _AssetTile({
     required this.asset,
@@ -540,11 +526,11 @@ class _AssetTile extends StatelessWidget {
               ],
             ),
             const SizedBox(width: 4),
-            PopupMenuButton<int?>(
+            PopupMenuButton<int>(
               icon: const Icon(Icons.more_vert, size: 20, color: Colors.grey),
               tooltip: strings.selectIntermediary,
-              itemBuilder: (_) => <PopupMenuEntry<int?>>[
-                PopupMenuItem<int?>(
+              itemBuilder: (_) => <PopupMenuEntry<int>>[
+                PopupMenuItem<int>(
                   enabled: false,
                   child: Text(
                     strings.selectIntermediary,
@@ -553,7 +539,7 @@ class _AssetTile extends StatelessWidget {
                 ),
                 const PopupMenuDivider(),
                 for (final i in intermediaries)
-                  PopupMenuItem<int?>(
+                  PopupMenuItem<int>(
                     value: i.id,
                     child: Row(
                       children: [
@@ -565,18 +551,6 @@ class _AssetTile extends StatelessWidget {
                       ],
                     ),
                   ),
-                PopupMenuItem<int?>(
-                  value: null,
-                  child: Row(
-                    children: [
-                      const Icon(Icons.folder_open, size: 18),
-                      const SizedBox(width: 8),
-                      Expanded(child: Text(strings.unassigned)),
-                      if (asset.intermediaryId == null)
-                        const Icon(Icons.check, size: 18),
-                    ],
-                  ),
-                ),
               ],
               onSelected: onMove,
             ),
@@ -671,6 +645,7 @@ class _CreateAssetDialogState extends State<_CreateAssetDialog> {
   final _manualNameCtrl = TextEditingController();
   InstrumentType? _instrumentType;
   AssetClass? _assetClass;
+  int? _selectedIntermediaryId;
 
   @override
   void dispose() {
@@ -871,29 +846,95 @@ class _CreateAssetDialogState extends State<_CreateAssetDialog> {
               ),
             ],
           ),
+          const SizedBox(height: 16),
+          _buildIntermediaryPicker(s),
         ],
       ),
       actions: [
         TextButton(onPressed: _backToSearch, child: Text(s.back)),
         FilledButton(
-          onPressed: () async {
-            final baseCurrency = widget.ref.read(baseCurrencyProvider).value ?? 'EUR';
-            final exchange = _selectedExchange ?? 'MIL';
-            final currency = exchangeCodeToCurrency[exchange] ?? baseCurrency;
-            await widget.ref.read(assetServiceProvider).create(
-                  name: r.description,
-                  ticker: r.symbol.isNotEmpty ? r.symbol : null,
-                  exchange: exchange,
-                  currency: currency,
-                  instrumentType: _instrumentType,
-                  assetClass: _assetClass,
-                );
-            if (mounted) Navigator.pop(context);
-          },
+          onPressed: _selectedIntermediaryId != null
+              ? () async {
+                  final baseCurrency = widget.ref.read(baseCurrencyProvider).value ?? 'EUR';
+                  final exchange = _selectedExchange ?? 'MIL';
+                  final currency = exchangeCodeToCurrency[exchange] ?? baseCurrency;
+                  await widget.ref.read(assetServiceProvider).create(
+                        name: r.description,
+                        ticker: r.symbol.isNotEmpty ? r.symbol : null,
+                        exchange: exchange,
+                        currency: currency,
+                        instrumentType: _instrumentType,
+                        assetClass: _assetClass,
+                        intermediaryId: _selectedIntermediaryId!,
+                      );
+                  if (mounted) Navigator.pop(context);
+                }
+              : null,
           child: Text(s.create),
         ),
       ],
     );
+  }
+
+  Widget _buildIntermediaryPicker(AppStrings s) {
+    final intermediariesAsync = widget.ref.watch(intermediariesProvider);
+    final list = intermediariesAsync.value ?? const <Intermediary>[];
+    if (list.isEmpty) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(s.selectIntermediaryEmpty, style: const TextStyle(fontSize: 13, color: Colors.grey)),
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            icon: const Icon(Icons.add, size: 18),
+            label: Text(s.addIntermediary),
+            onPressed: _createIntermediaryInline,
+          ),
+        ],
+      );
+    }
+    return DropdownButtonFormField<int>(
+      initialValue: _selectedIntermediaryId,
+      decoration: InputDecoration(labelText: s.selectIntermediary, isDense: true),
+      items: list
+          .map((i) => DropdownMenuItem(value: i.id, child: Text(i.name, style: const TextStyle(fontSize: 13))))
+          .toList(),
+      onChanged: (v) {
+        if (v != null) setState(() => _selectedIntermediaryId = v);
+      },
+    );
+  }
+
+  Future<void> _createIntermediaryInline() async {
+    final s = widget.ref.read(appStringsProvider);
+    final nameCtrl = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: Text(s.addIntermediary),
+          content: TextField(
+            controller: nameCtrl,
+            decoration: InputDecoration(labelText: s.intermediaryName),
+            autofocus: true,
+            onChanged: (_) => setDialogState(() {}),
+          ),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(ctx), child: Text(s.cancel)),
+            FilledButton(
+              onPressed: nameCtrl.text.trim().isNotEmpty
+                  ? () => Navigator.pop(ctx, nameCtrl.text.trim())
+                  : null,
+              child: Text(s.create),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (name == null || name.isEmpty) return;
+    final svc = widget.ref.read(intermediaryServiceProvider);
+    final id = await svc.create(name: name);
+    if (mounted) setState(() => _selectedIntermediaryId = id);
   }
 
   Widget _buildManualDialog() {
@@ -941,12 +982,14 @@ class _CreateAssetDialogState extends State<_CreateAssetDialog> {
               ),
             ],
           ),
+          const SizedBox(height: 16),
+          _buildIntermediaryPicker(s),
         ],
       ),
       actions: [
         TextButton(onPressed: _backToSearch, child: Text(s.back)),
         FilledButton(
-          onPressed: _manualNameCtrl.text.trim().isNotEmpty
+          onPressed: (_manualNameCtrl.text.trim().isNotEmpty && _selectedIntermediaryId != null)
               ? () async {
                   final name = _manualNameCtrl.text.trim();
                   final baseCurrency = widget.ref.read(baseCurrencyProvider).value ?? 'EUR';
@@ -956,6 +999,7 @@ class _CreateAssetDialogState extends State<_CreateAssetDialog> {
                         valuationMethod: ValuationMethod.eventDriven,
                         instrumentType: _instrumentType,
                         assetClass: _assetClass,
+                        intermediaryId: _selectedIntermediaryId!,
                       );
                   if (mounted) Navigator.pop(context);
                 }

--- a/lib/ui/screens/import/confirm_step.dart
+++ b/lib/ui/screens/import/confirm_step.dart
@@ -253,12 +253,20 @@ extension _ConfirmStep on _ImportScreenState {
               FilledButton.icon(
                 icon: const Icon(Icons.check),
                 label: Text(s.importButton),
-                onPressed: (isAssetImport || isIncomeImport || _targetId != null) ? _executeImport : null,
+                onPressed: _canImport(isAssetImport, isIncomeImport) ? _executeImport : null,
               ),
             ],
           ),
       ],
     );
+  }
+
+  /// Asset imports require an intermediary selection. Income imports don't.
+  /// Transaction imports require a target account.
+  bool _canImport(bool isAssetImport, bool isIncomeImport) {
+    if (isAssetImport) return _selectedIntermediaryId != null;
+    if (isIncomeImport) return true;
+    return _targetId != null;
   }
 
   Widget _buildIntermediarySelector() {
@@ -267,7 +275,20 @@ extension _ConfirmStep on _ImportScreenState {
     return intermediariesAsync.when(
       data: (intermediaries) {
         if (intermediaries.isEmpty) {
-          return Text(s.unassigned, style: const TextStyle(color: Colors.grey));
+          // Empty state: give the user an inline CTA to create one.
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(s.selectIntermediaryEmpty,
+                  style: const TextStyle(color: Colors.grey)),
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                icon: const Icon(Icons.add),
+                label: Text(s.addIntermediary),
+                onPressed: _createIntermediaryInline,
+              ),
+            ],
+          );
         }
         return RadioGroup<int?>(
           groupValue: _selectedIntermediaryId,
@@ -278,9 +299,13 @@ extension _ConfirmStep on _ImportScreenState {
                 title: Text(i.name),
                 value: i.id,
               )),
-              RadioListTile<int?>(
-                title: Text(s.unassigned),
-                value: null,
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  icon: const Icon(Icons.add, size: 18),
+                  label: Text(s.addIntermediary),
+                  onPressed: _createIntermediaryInline,
+                ),
               ),
             ],
           ),
@@ -289,6 +314,38 @@ extension _ConfirmStep on _ImportScreenState {
       loading: () => const CircularProgressIndicator(),
       error: (e, _) => Text(s.error(e)),
     );
+  }
+
+  Future<void> _createIntermediaryInline() async {
+    final s = ref.read(appStringsProvider);
+    final nameCtrl = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: Text(s.addIntermediary),
+          content: TextField(
+            controller: nameCtrl,
+            decoration: InputDecoration(labelText: s.intermediaryName),
+            autofocus: true,
+            onChanged: (_) => setDialogState(() {}),
+          ),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(ctx), child: Text(s.cancel)),
+            FilledButton(
+              onPressed: nameCtrl.text.trim().isNotEmpty
+                  ? () => Navigator.pop(ctx, nameCtrl.text.trim())
+                  : null,
+              child: Text(s.create),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (name == null || name.isEmpty) return;
+    final svc = ref.read(intermediaryServiceProvider);
+    final id = await svc.create(name: name);
+    if (mounted) _setState(() => _selectedIntermediaryId = id);
   }
 
   Widget _buildImportPreview() {
@@ -479,7 +536,7 @@ extension _ConfirmStep on _ImportScreenState {
           excludedIsins: _excludedIsins.isNotEmpty ? _excludedIsins : null,
           rateService: ref.read(exchangeRateServiceProvider),
           baseCurrency: ref.read(baseCurrencyProvider).value ?? 'EUR',
-          intermediaryId: _selectedIntermediaryId,
+          intermediaryId: _selectedIntermediaryId!, // gated by _canImport
         );
         result = assetResult.result;
       }

--- a/lib/ui/screens/import/confirm_step.dart
+++ b/lib/ui/screens/import/confirm_step.dart
@@ -86,6 +86,9 @@ extension _ConfirmStep on _ImportScreenState {
                   const SizedBox(height: 24),
                 ],
 
+                _buildNumberLocalePicker(),
+                const SizedBox(height: 16),
+
                 // Summary
                 Card(
                   child: Padding(
@@ -292,7 +295,17 @@ extension _ConfirmStep on _ImportScreenState {
         }
         return RadioGroup<int?>(
           groupValue: _selectedIntermediaryId,
-          onChanged: (v) => _setState(() => _selectedIntermediaryId = v),
+          onChanged: (v) async {
+            _setState(() => _selectedIntermediaryId = v);
+            // Pre-load this intermediary's persisted number-format locale.
+            if (v != null) {
+              final all = await ref.read(intermediaryServiceProvider).getAll();
+              final inter = all.where((i) => i.id == v).firstOrNull;
+              if (mounted && inter != null) {
+                _setState(() => _selectedNumberLocale = inter.defaultImportLocale);
+              }
+            }
+          },
           child: Column(
             children: [
               ...intermediaries.map((i) => RadioListTile<int?>(
@@ -497,6 +510,8 @@ extension _ConfirmStep on _ImportScreenState {
         });
       }
 
+      final appLocale = ref.read(appLocaleProvider).value;
+
       final ImportResult result;
       if (_target == ImportTarget.transaction) {
         result = await importer.importTransactions(
@@ -507,6 +522,8 @@ extension _ConfirmStep on _ImportScreenState {
           balanceMode: _balanceMode,
           balanceFilterColumn: _balanceFilterColumn,
           balanceFilterInclude: _balanceFilterInclude.isNotEmpty ? _balanceFilterInclude : null,
+          numberLocaleOverride: _selectedNumberLocale,
+          appLocale: appLocale,
         );
       } else if (_target == ImportTarget.income) {
         final baseCurrency = ref.read(baseCurrencyProvider).value ?? 'EUR';
@@ -515,6 +532,8 @@ extension _ConfirmStep on _ImportScreenState {
           mappings: mappings,
           defaultCurrency: baseCurrency,
           onProgress: onProgress,
+          numberLocaleOverride: _selectedNumberLocale,
+          appLocale: appLocale,
         );
       } else {
         // Remove type mapping if using sign-based detection
@@ -537,6 +556,8 @@ extension _ConfirmStep on _ImportScreenState {
           rateService: ref.read(exchangeRateServiceProvider),
           baseCurrency: ref.read(baseCurrencyProvider).value ?? 'EUR',
           intermediaryId: _selectedIntermediaryId!, // gated by _canImport
+          numberLocaleOverride: _selectedNumberLocale,
+          appLocale: appLocale,
         );
         result = assetResult.result;
       }
@@ -573,5 +594,53 @@ extension _ConfirmStep on _ImportScreenState {
         _importing = false;
       });
     }
+  }
+
+  /// Locales the user can pick for number-format parsing in the wizard.
+  /// `null` value = "Auto" (resolve from app locale at import time).
+  static const List<(String?, String)> _numberLocaleOptions = [
+    (null, 'Auto'),
+    ('it_IT', 'Italiano (it_IT)'),
+    ('en_US', 'English / US (en_US)'),
+    ('en_GB', 'English / UK (en_GB)'),
+    ('de_DE', 'Deutsch (de_DE)'),
+    ('fr_FR', 'Français (fr_FR)'),
+    ('es_ES', 'Español (es_ES)'),
+  ];
+
+  Widget _buildNumberLocalePicker() {
+    final s = ref.watch(appStringsProvider);
+    final appLocale = ref.watch(appLocaleProvider).value;
+    final autoLabel = appLocale != null && appLocale.isNotEmpty
+        ? 'Auto ($appLocale)'
+        : 'Auto';
+    final items = _numberLocaleOptions.map((opt) {
+      final label = opt.$1 == null ? autoLabel : opt.$2;
+      return DropdownMenuItem<String?>(
+        value: opt.$1,
+        child: Text(label),
+      );
+    }).toList();
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                s.numberFormatLabel,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+            DropdownButton<String?>(
+              value: _selectedNumberLocale,
+              hint: Text(autoLabel),
+              items: items,
+              onChanged: (v) => _setState(() => _selectedNumberLocale = v),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/ui/screens/import/import_screen.dart
+++ b/lib/ui/screens/import/import_screen.dart
@@ -83,6 +83,12 @@ class _ImportScreenState extends ConsumerState<ImportScreen> {
   int? _targetId; // accountId or assetId
   int? _selectedIntermediaryId; // for asset imports
 
+  /// Number-format locale chosen in the wizard. `null` = "Auto" (resolved
+  /// from the per-source saved value or from the app locale at import time).
+  /// When the user explicitly picks a value here, it is persisted to the
+  /// import-source config (per account / per intermediary / global income).
+  String? _selectedNumberLocale;
+
   // Asset import mode: 'historic' (date+rate required) or 'current' (default to today, rate auto-fetched)
   String _assetImportMode = 'historic';
 
@@ -438,6 +444,7 @@ class _ImportScreenState extends ConsumerState<ImportScreen> {
 
     _log.info('_loadSavedConfig: found config for account $accountId');
     _savedConfig = config;
+    _selectedNumberLocale = config.numberLocale;
 
     // Check if noHeader is saved -- need to set before re-parse
     final savedMappings = (jsonDecode(config.mappingsJson) as Map<String, dynamic>);
@@ -772,6 +779,7 @@ class _ImportScreenState extends ConsumerState<ImportScreen> {
         fullPreview = await importer.getFullRows(fullPreview);
       }
 
+      final appLocale = ref.read(appLocaleProvider).value;
       if (_target == ImportTarget.transaction && _targetId != null) {
         final result = await importer.previewTransactionImport(
           preview: fullPreview,
@@ -780,6 +788,8 @@ class _ImportScreenState extends ConsumerState<ImportScreen> {
           balanceMode: _balanceMode,
           balanceFilterColumn: _balanceFilterColumn,
           balanceFilterInclude: _balanceFilterInclude.isNotEmpty ? _balanceFilterInclude : null,
+          numberLocale: _selectedNumberLocale,
+          appLocale: appLocale,
         );
         if (mounted) _setState(() => _txPreview = result);
       } else if (_target == ImportTarget.assetEvent) {
@@ -794,6 +804,8 @@ class _ImportScreenState extends ConsumerState<ImportScreen> {
           sellValues: _sellValues.isNotEmpty ? _sellValues : null,
           excludedIsins: _excludedIsins.isNotEmpty ? _excludedIsins : null,
           selectedExchanges: _selectedExchanges.isNotEmpty ? _selectedExchanges : null,
+          numberLocale: _selectedNumberLocale,
+          appLocale: appLocale,
         );
         if (mounted) _setState(() => _assetPreview = result);
       }

--- a/lib/utils/amount_parser.dart
+++ b/lib/utils/amount_parser.dart
@@ -1,58 +1,31 @@
-/// Parses amount/balance strings, handling both European (1.234,56) and
-/// standard (1,234.56) number formats.
-double parseAmount(String s) {
-  s = s.trim();
-  if (s.isEmpty) throw const FormatException('Empty amount');
+import 'package:intl/intl.dart';
 
-  // Remove currency symbols and whitespace used as thousands separator
-  s = s.replaceAll(RegExp(r'[€$£¥\s]'), '').trim();
-
-  // Both dot and comma present → disambiguate by position
-  if (s.contains(',') && s.contains('.')) {
-    final lastComma = s.lastIndexOf(',');
-    final lastDot = s.lastIndexOf('.');
-    if (lastComma > lastDot) {
-      // European: dots are thousands, comma is decimal (1.234,56)
-      s = s.replaceAll('.', '').replaceAll(',', '.');
-    } else {
-      // Standard: commas are thousands, dot is decimal (1,234.56)
-      s = s.replaceAll(',', '');
-    }
-  } else if (s.contains(',')) {
-    // Comma only: ≤2 digits after → decimal, 3 digits → thousands
-    final parts = s.split(',');
-    if (parts.length > 2) {
-      // Multiple commas: definitely thousands (1,234,567)
-      s = s.replaceAll(',', '');
-    } else if (parts.last.length == 3) {
-      // Exactly 3 digits after comma: thousands separator (1,234)
-      s = s.replaceAll(',', '');
-    } else {
-      // 1-2 digits after comma: decimal separator (1,5 or 1,50)
-      s = s.replaceAll(',', '.');
-    }
-  } else if (s.contains('.')) {
-    // Dot only: ≤2 digits after → decimal, 3 digits → thousands
-    final parts = s.split('.');
-    if (parts.length > 2) {
-      // Multiple dots: definitely thousands (1.234.567)
-      s = s.replaceAll('.', '');
-    } else if (parts.last.length == 3 && parts.first.isNotEmpty) {
-      // Exactly 3 digits after dot: thousands separator (1.234)
-      s = s.replaceAll('.', '');
-    }
-    // Otherwise: decimal point (1.5, 12.34, etc.) — keep as is
-  }
-
-  return double.parse(s);
+/// Parses an amount/balance string under the given locale.
+///
+/// Locale must be an ICU locale tag the app uses (e.g. `it_IT`, `en_US`,
+/// `de_DE`, `fr_FR`, `es_ES`, `en_GB`). The decimal/thousands separators
+/// come from the locale — no heuristic guessing.
+double parseAmount(String s, {required String locale}) {
+  final cleaned = s.replaceAll(RegExp(r'[€$£¥]'), '').trim();
+  if (cleaned.isEmpty) throw const FormatException('Empty amount');
+  return NumberFormat.decimalPattern(locale).parse(cleaned).toDouble();
 }
 
-/// Like [parseAmount] but returns null on failure instead of throwing.
-double? tryParseAmount(String? s) {
+/// Like [parseAmount] but returns null on null/empty/parse-failure.
+double? tryParseAmount(String? s, {required String locale}) {
   if (s == null || s.trim().isEmpty) return null;
   try {
-    return parseAmount(s);
+    return parseAmount(s, locale: locale);
   } catch (_) {
     return null;
   }
 }
+
+/// Pick the effective locale to parse an import file under.
+///
+/// Priority:
+///  1. The user's per-source override (`saved`), if any.
+///  2. The app's configured locale (`appLocale`).
+///  3. `en_US` as a final safety net.
+String resolveImportLocale({String? saved, required String? appLocale}) =>
+    saved ?? appLocale ?? 'en_US';

--- a/test/allocation_computation_test.dart
+++ b/test/allocation_computation_test.dart
@@ -21,6 +21,7 @@ Asset _makeAsset({
     assetType: AssetType.stockEtf,
     instrumentType: instrumentType,
     assetClass: assetClass,
+    intermediaryId: 1,
     assetGroup: '',
     currency: currency,
     country: country,

--- a/test/amount_parser_test.dart
+++ b/test/amount_parser_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:finance_copilot/utils/amount_parser.dart';
+
+void main() {
+  group('parseAmount with locale', () {
+    test('it_IT: comma is decimal, dot is thousands', () {
+      expect(parseAmount('80,000', locale: 'it_IT'), 80.0);
+      expect(parseAmount('81,050', locale: 'it_IT'), closeTo(81.05, 1e-9));
+      expect(parseAmount('5.975,00', locale: 'it_IT'), 5975.0);
+      expect(parseAmount('1.234.567', locale: 'it_IT'), 1234567.0);
+      expect(parseAmount('10.000,000', locale: 'it_IT'), 10000.0);
+      expect(parseAmount('-384,60', locale: 'it_IT'), closeTo(-384.6, 1e-9));
+    });
+
+    test('en_US: comma is thousands, dot is decimal', () {
+      expect(parseAmount('80,000', locale: 'en_US'), 80000.0);
+      expect(parseAmount('1,234.56', locale: 'en_US'), closeTo(1234.56, 1e-9));
+      expect(parseAmount('5,975.00', locale: 'en_US'), 5975.0);
+      expect(parseAmount('1,234,567', locale: 'en_US'), 1234567.0);
+    });
+
+    test('de_DE: comma decimal, dot thousands', () {
+      expect(parseAmount('1.234.567', locale: 'de_DE'), 1234567.0);
+      expect(parseAmount('1.234,56', locale: 'de_DE'), closeTo(1234.56, 1e-9));
+    });
+
+    test('strips currency symbols and whitespace', () {
+      expect(parseAmount('€ 1.234,56', locale: 'it_IT'), closeTo(1234.56, 1e-9));
+      expect(parseAmount('\$1,234.56', locale: 'en_US'), closeTo(1234.56, 1e-9));
+      expect(parseAmount(' 80,000 ', locale: 'it_IT'), 80.0);
+    });
+
+    test('throws on empty', () {
+      expect(() => parseAmount('', locale: 'it_IT'), throwsFormatException);
+    });
+
+    test('throws on garbage', () {
+      expect(() => parseAmount('abc', locale: 'it_IT'), throwsFormatException);
+    });
+  });
+
+  group('tryParseAmount', () {
+    test('returns null on empty/null', () {
+      expect(tryParseAmount(null, locale: 'it_IT'), isNull);
+      expect(tryParseAmount('', locale: 'it_IT'), isNull);
+      expect(tryParseAmount('   ', locale: 'it_IT'), isNull);
+    });
+
+    test('returns null on garbage', () {
+      expect(tryParseAmount('abc', locale: 'it_IT'), isNull);
+    });
+
+    test('parses valid input', () {
+      expect(tryParseAmount('80,000', locale: 'it_IT'), 80.0);
+    });
+  });
+
+  group('resolveImportLocale', () {
+    test('saved wins over appLocale', () {
+      expect(
+        resolveImportLocale(saved: 'en_US', appLocale: 'it_IT'),
+        'en_US',
+      );
+    });
+
+    test('falls back to appLocale when saved is null', () {
+      expect(
+        resolveImportLocale(saved: null, appLocale: 'it_IT'),
+        'it_IT',
+      );
+    });
+
+    test('falls back to en_US when both null', () {
+      expect(
+        resolveImportLocale(saved: null, appLocale: null),
+        'en_US',
+      );
+    });
+  });
+}

--- a/test/asset_event_service_test.dart
+++ b/test/asset_event_service_test.dart
@@ -9,6 +9,7 @@ import 'package:finance_copilot/services/asset_event_service.dart';
 void main() {
   late AppDatabase db;
   late AssetEventService service;
+  late int iid;
 
   /// Helper: insert a parent asset and return its id.
   Future<int> createAsset(String name) async {
@@ -18,12 +19,14 @@ void main() {
           instrumentType: const Value(InstrumentType.etf),
           assetClass: const Value(AssetClass.equity),
           valuationMethod: ValuationMethod.eventDriven,
+          intermediaryId: iid,
         ));
   }
 
-  setUp(() {
+  setUp(() async {
     db = AppDatabase.forTesting(NativeDatabase.memory());
     service = AssetEventService(db);
+    iid = await db.into(db.intermediaries).insert(IntermediariesCompanion.insert(name: 'Default'));
   });
 
   tearDown(() async => await db.close());

--- a/test/asset_service_test.dart
+++ b/test/asset_service_test.dart
@@ -9,17 +9,21 @@ import 'package:finance_copilot/services/asset_service.dart';
 void main() {
   late AppDatabase db;
   late AssetService service;
+  late int iid;
 
-  setUp(() {
+  setUp(() async {
     db = AppDatabase.forTesting(NativeDatabase.memory());
     service = AssetService(db);
+    iid = await db.into(db.intermediaries).insert(
+      IntermediariesCompanion.insert(name: 'Default'),
+    );
   });
 
   tearDown(() async => await db.close());
 
   group('create and retrieve', () {
     test('create returns an id and getById retrieves it', () async {
-      final id = await service.create(name: 'VWCE', currency: 'EUR');
+      final id = await service.create(name: 'VWCE', currency: 'EUR', intermediaryId: iid);
       expect(id, greaterThan(0));
 
       final asset = await service.getById(id);
@@ -35,6 +39,7 @@ void main() {
         exchange: 'NASDAQ',
         currency: 'USD',
         taxRate: 0.26,
+        intermediaryId: iid,
       );
 
       final asset = await service.getById(id);
@@ -46,8 +51,8 @@ void main() {
     });
 
     test('getAll returns all assets', () async {
-      await service.create(name: 'A', currency: 'EUR');
-      await service.create(name: 'B', currency: 'EUR');
+      await service.create(name: 'A', currency: 'EUR', intermediaryId: iid);
+      await service.create(name: 'B', currency: 'EUR', intermediaryId: iid);
 
       final all = await service.getAll();
       expect(all.length, 2);
@@ -56,7 +61,7 @@ void main() {
 
   group('update', () {
     test('update ticker', () async {
-      final id = await service.create(name: 'Test', currency: 'EUR');
+      final id = await service.create(name: 'Test', currency: 'EUR', intermediaryId: iid);
       final result = await service.update(
         id,
         const AssetsCompanion(ticker: Value('TST')),
@@ -68,7 +73,7 @@ void main() {
     });
 
     test('update isin', () async {
-      final id = await service.create(name: 'Test', currency: 'EUR');
+      final id = await service.create(name: 'Test', currency: 'EUR', intermediaryId: iid);
       await service.update(
         id,
         const AssetsCompanion(isin: Value('IE00BK5BQT80')),
@@ -89,7 +94,7 @@ void main() {
 
   group('delete', () {
     test('delete removes the asset', () async {
-      final id = await service.create(name: 'ToDelete', currency: 'EUR');
+      final id = await service.create(name: 'ToDelete', currency: 'EUR', intermediaryId: iid);
       final deleted = await service.delete(id);
       expect(deleted, 1);
 
@@ -98,7 +103,7 @@ void main() {
     });
 
     test('delete cascades events', () async {
-      final assetId = await service.create(name: 'WithEvents', currency: 'EUR');
+      final assetId = await service.create(name: 'WithEvents', currency: 'EUR', intermediaryId: iid);
 
       // Insert events directly
       await db.into(db.assetEvents).insert(AssetEventsCompanion.insert(
@@ -137,16 +142,16 @@ void main() {
 
   group('deleteMany', () {
     test('empty list is a no-op', () async {
-      await service.create(name: 'Keep', currency: 'EUR');
+      await service.create(name: 'Keep', currency: 'EUR', intermediaryId: iid);
       final n = await service.deleteMany([]);
       expect(n, 0);
       expect((await service.getAll()).length, 1);
     });
 
     test('removes multiple assets in one call', () async {
-      final a = await service.create(name: 'A', currency: 'EUR');
-      final b = await service.create(name: 'B', currency: 'EUR');
-      final c = await service.create(name: 'C', currency: 'EUR');
+      final a = await service.create(name: 'A', currency: 'EUR', intermediaryId: iid);
+      final b = await service.create(name: 'B', currency: 'EUR', intermediaryId: iid);
+      final c = await service.create(name: 'C', currency: 'EUR', intermediaryId: iid);
 
       final n = await service.deleteMany([a, c]);
       expect(n, 2);
@@ -156,9 +161,9 @@ void main() {
     });
 
     test('cascades events, snapshots and prices for all deleted assets', () async {
-      final a = await service.create(name: 'A', currency: 'EUR');
-      final b = await service.create(name: 'B', currency: 'EUR');
-      final keep = await service.create(name: 'Keep', currency: 'EUR');
+      final a = await service.create(name: 'A', currency: 'EUR', intermediaryId: iid);
+      final b = await service.create(name: 'B', currency: 'EUR', intermediaryId: iid);
+      final keep = await service.create(name: 'Keep', currency: 'EUR', intermediaryId: iid);
 
       for (final id in [a, b, keep]) {
         await db.into(db.assetEvents).insert(AssetEventsCompanion.insert(
@@ -198,9 +203,9 @@ void main() {
 
   group('reorder', () {
     test('reorder updates sortOrder', () async {
-      final id1 = await service.create(name: 'A', currency: 'EUR');
-      final id2 = await service.create(name: 'B', currency: 'EUR');
-      final id3 = await service.create(name: 'C', currency: 'EUR');
+      final id1 = await service.create(name: 'A', currency: 'EUR', intermediaryId: iid);
+      final id2 = await service.create(name: 'B', currency: 'EUR', intermediaryId: iid);
+      final id3 = await service.create(name: 'C', currency: 'EUR', intermediaryId: iid);
 
       await service.reorder([id3, id1, id2]);
 
@@ -216,13 +221,13 @@ void main() {
 
   group('getStatsForAll', () {
     test('returns empty map when no events', () async {
-      await service.create(name: 'NoEvents', currency: 'EUR');
+      await service.create(name: 'NoEvents', currency: 'EUR', intermediaryId: iid);
       final stats = await service.getStatsForAll();
       expect(stats, isEmpty);
     });
 
     test('returns correct stats with buy events', () async {
-      final assetId = await service.create(name: 'Stats', currency: 'EUR');
+      final assetId = await service.create(name: 'Stats', currency: 'EUR', intermediaryId: iid);
 
       await db.into(db.assetEvents).insert(AssetEventsCompanion.insert(
             assetId: assetId,
@@ -255,7 +260,7 @@ void main() {
     });
 
     test('sell events reduce totalQuantity', () async {
-      final assetId = await service.create(name: 'BuySell', currency: 'EUR');
+      final assetId = await service.create(name: 'BuySell', currency: 'EUR', intermediaryId: iid);
 
       await db.into(db.assetEvents).insert(AssetEventsCompanion.insert(
             assetId: assetId,
@@ -282,7 +287,7 @@ void main() {
     });
 
     test('revalue events do not affect quantity or invested', () async {
-      final assetId = await service.create(name: 'RevalueTest', currency: 'EUR');
+      final assetId = await service.create(name: 'RevalueTest', currency: 'EUR', intermediaryId: iid);
 
       await db.into(db.assetEvents).insert(AssetEventsCompanion.insert(
             assetId: assetId,

--- a/test/batch_equivalence_test.dart
+++ b/test/batch_equivalence_test.dart
@@ -16,9 +16,11 @@ import 'package:finance_copilot/services/investing_com_service.dart';
 
 void main() {
   late AppDatabase db;
+  late int iid;
 
-  setUp(() {
+  setUp(() async {
     db = AppDatabase.forTesting(NativeDatabase.memory());
+    iid = await db.into(db.intermediaries).insert(IntermediariesCompanion.insert(name: 'Default'));
   });
 
   tearDown(() async => await db.close());
@@ -32,6 +34,7 @@ void main() {
       name: name,
       assetType: AssetType.stockEtf,
       valuationMethod: valuation,
+      intermediaryId: iid,
     ));
   }
 

--- a/test/database_test.dart
+++ b/test/database_test.dart
@@ -85,6 +85,9 @@ void main() {
 
   group('Asset & AssetEvent', () {
     test('insert asset with events and snapshot', () async {
+      final iid = await db.into(db.intermediaries).insert(
+        IntermediariesCompanion.insert(name: 'Default'),
+      );
       final assetId = await db.into(db.assets).insert(
         AssetsCompanion.insert(
           name: 'iShares Core MSCI World',
@@ -92,6 +95,7 @@ void main() {
           instrumentType: const Value(InstrumentType.etf),
           assetClass: const Value(AssetClass.equity),
           valuationMethod: ValuationMethod.marketPrice,
+          intermediaryId: iid,
         ),
       );
 

--- a/test/import_service_test.dart
+++ b/test/import_service_test.dart
@@ -14,11 +14,17 @@ void main() {
   late AppDatabase db;
   late ImportService importer;
   late Directory tempDir;
+  // Every asset needs an intermediary (schema v29). Tests that don't care
+  // about intermediary specifics use this default.
+  late int defaultIntermediaryId;
 
-  setUp(() {
+  setUp(() async {
     db = AppDatabase.forTesting(NativeDatabase.memory());
     importer = ImportService(db);
     tempDir = Directory.systemTemp.createTempSync('import_test_');
+    defaultIntermediaryId = await db.into(db.intermediaries).insert(
+      IntermediariesCompanion.insert(name: 'Default'),
+    );
   });
 
   tearDown(() async {
@@ -370,6 +376,7 @@ Date,Amount
       ]);
       final result = await importer.importAssetEventsGrouped(
         preview: preview, mappings: mappings, baseCurrency: 'EUR',
+        intermediaryId: defaultIntermediaryId,
       );
       expect(result.result.importedRows, 1);
 
@@ -385,6 +392,7 @@ Date,Amount
       // Provide a selected exchange with Investing.com name
       final result = await importer.importAssetEventsGrouped(
         preview: preview, mappings: mappings, baseCurrency: 'EUR',
+        intermediaryId: defaultIntermediaryId,
         selectedExchanges: {
           'IE00B4L5Y983': const IsinExchangeOption(
             cid: 46925, ticker: 'SWDA', name: 'iShares MSCI World',
@@ -404,6 +412,7 @@ Date,Amount
       ]);
       final result = await importer.importAssetEventsGrouped(
         preview: preview, mappings: mappings, baseCurrency: 'EUR',
+        intermediaryId: defaultIntermediaryId,
         excludedIsins: {'LU0908500753'},
       );
       expect(result.result.importedRows, 1);
@@ -422,6 +431,7 @@ Date,Amount
         isin: const Value('IE00B4L5Y983'),
         exchange: const Value('MIL'),
         ter: const Value(0.20),
+        intermediaryId: defaultIntermediaryId,
       ));
 
       final preview = makeAssetPreview([
@@ -429,6 +439,7 @@ Date,Amount
       ]);
       final result = await importer.importAssetEventsGrouped(
         preview: preview, mappings: mappings, baseCurrency: 'EUR',
+        intermediaryId: defaultIntermediaryId,
       );
 
       // Should reuse existing asset, preserving TER
@@ -447,6 +458,7 @@ Date,Amount
         assetClass: const Value(AssetClass.fixedIncome),
         valuationMethod: ValuationMethod.marketPrice,
         isin: const Value('XS1234567890'),
+        intermediaryId: defaultIntermediaryId,
       ));
 
       // Use mappings WITHOUT amount so the auto-calc path (qty * price / 100) fires
@@ -467,6 +479,7 @@ Date,Amount
 
       final result = await importer.importAssetEventsGrouped(
         preview: preview, mappings: bondMappings, baseCurrency: 'EUR',
+        intermediaryId: defaultIntermediaryId,
       );
 
       expect(result.result.importedRows, 1);
@@ -631,6 +644,7 @@ Date,Amount
       ]);
       await importer.importAssetEventsGrouped(
         preview: preview1, mappings: datedMappings, baseCurrency: 'EUR',
+        intermediaryId: defaultIntermediaryId,
       );
       var events = await db.select(db.assetEvents).get();
       expect(events.length, 2);
@@ -641,6 +655,7 @@ Date,Amount
       ]);
       await importer.importAssetEventsGrouped(
         preview: preview2, mappings: datedMappings, baseCurrency: 'EUR',
+        intermediaryId: defaultIntermediaryId,
       );
 
       events = await db.select(db.assetEvents).get();
@@ -790,63 +805,8 @@ Date,Amount
       expect(events.first.quantity, 10.0);
     });
 
-    test('spot re-import without intermediary replaces only unassigned asset events', () async {
-      final intermediaryId = await db.into(db.intermediaries).insert(
-        IntermediariesCompanion.insert(name: 'Broker B'),
-      );
-
-      // Create assigned asset (Broker B) with a pre-existing event
-      final assignedAssetId = await db.into(db.assets).insert(AssetsCompanion.insert(
-        name: 'SWDA assigned',
-        assetType: AssetType.stockEtf,
-        valuationMethod: ValuationMethod.marketPrice,
-        isin: const Value('IE00B4L5Y983'),
-        intermediaryId: Value(intermediaryId),
-      ));
-      await db.into(db.assetEvents).insert(AssetEventsCompanion.insert(
-        assetId: assignedAssetId,
-        date: DateTime(2024, 1, 1),
-        valueDate: DateTime(2024, 1, 1),
-        type: EventType.buy,
-        amount: 500,
-        quantity: const Value(5),
-      ));
-
-      // Create unassigned asset (same ISIN, no intermediary) with event
-      final unassignedAssetId = await db.into(db.assets).insert(AssetsCompanion.insert(
-        name: 'SWDA unassigned',
-        assetType: AssetType.stockEtf,
-        valuationMethod: ValuationMethod.marketPrice,
-        isin: const Value('IE00B4L5Y983'),
-        // no intermediaryId
-      ));
-      await db.into(db.assetEvents).insert(AssetEventsCompanion.insert(
-        assetId: unassignedAssetId,
-        date: DateTime(2024, 1, 1),
-        valueDate: DateTime(2024, 1, 1),
-        type: EventType.buy,
-        amount: 300,
-        quantity: const Value(3),
-      ));
-
-      // Spot re-import of the unassigned asset (intermediaryId: null)
-      // The import will reuse the first matching ISIN asset (the assigned one),
-      // so we test by checking that the unassigned asset's old event is cleaned
-      // and the assigned one is untouched.
-      final preview = makeSpotPreview([
-        ['IE00B4L5Y983', '10', '100', 'EUR', '1000'],
-      ]);
-      await importer.importAssetEventsGrouped(
-        preview: preview, mappings: spotMappings, baseCurrency: 'EUR',
-        // intermediaryId: null (unassigned)
-      );
-
-      // The assigned event under Broker B must survive untouched
-      final assignedEvents = await (db.select(db.assetEvents)
-        ..where((e) => e.assetId.equals(assignedAssetId))).get();
-      expect(assignedEvents.length, 1, reason: 'assigned intermediary events must not be wiped');
-      expect(assignedEvents.first.quantity, 5.0);
-    });
+    // Removed: "spot re-import without intermediary" scenario is no longer
+    // valid since schema v29 — every asset must have an intermediary.
 
     test('spot re-import with intermediary does not wipe other intermediary events', () async {
       final brokerA = await db.into(db.intermediaries).insert(
@@ -874,11 +834,116 @@ Date,Amount
         intermediaryId: brokerA,
       );
 
-      // Broker B's events must survive
+      // Each broker holds its OWN asset row for this ISIN (same-ISIN-at-
+      // different-brokers scoping). Both events survive, on separate assets.
+      final assets = await (db.select(db.assets)..where((a) => a.isin.equals('IE00B4L5Y983'))).get();
+      expect(assets.length, 2, reason: 'one asset row per (ISIN, intermediary)');
       final allEvents = await db.select(db.assetEvents).get();
       expect(allEvents.length, 2); // 1 for each broker
       final quantities = allEvents.map((e) => e.quantity).toSet();
       expect(quantities, {10.0, 20.0});
+    });
+
+    test('issue #61: disjoint-ISIN spot imports under two intermediaries do not accumulate', () async {
+      final brokerA = await db.into(db.intermediaries).insert(
+        IntermediariesCompanion.insert(name: 'Broker A'),
+      );
+      final brokerB = await db.into(db.intermediaries).insert(
+        IntermediariesCompanion.insert(name: 'Broker B'),
+      );
+
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['AAAA00000001', '10', '100', 'EUR', '1000'],
+          ['AAAA00000002', '5',  '200', 'EUR', '1000'],
+          ['AAAA00000003', '2',  '300', 'EUR',  '600'],
+        ]),
+        mappings: spotMappings, baseCurrency: 'EUR',
+        intermediaryId: brokerA,
+      );
+      expect((await db.select(db.assetEvents).get()).length, 3);
+
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['BBBB00000001', '7', '50',  'EUR', '350'],
+          ['BBBB00000002', '4', '125', 'EUR', '500'],
+        ]),
+        mappings: spotMappings, baseCurrency: 'EUR',
+        intermediaryId: brokerB,
+      );
+      expect((await db.select(db.assetEvents).get()).length, 5,
+          reason: "A's 3 + B's 2 = 5 (disjoint ISINs, both portfolios preserved)");
+
+      // Re-import Broker A with NEW quantities. Pre-fix this would have left
+      // Broker A's old events behind because the wipe only scoped to the
+      // current batch's asset ids.
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['AAAA00000001', '20', '110', 'EUR', '2200'],
+          ['AAAA00000002', '15', '210', 'EUR', '3150'],
+          ['AAAA00000003', '12', '310', 'EUR', '3720'],
+        ]),
+        mappings: spotMappings, baseCurrency: 'EUR',
+        intermediaryId: brokerA,
+      );
+
+      final joined = await db.customSelect(
+        'SELECT ae.quantity, a.intermediary_id FROM asset_events ae '
+        'JOIN assets a ON a.id = ae.asset_id',
+      ).get();
+      final aQtys = joined.where((r) => r.read<int>('intermediary_id') == brokerA)
+          .map((r) => r.read<double>('quantity')).toList()..sort();
+      final bQtys = joined.where((r) => r.read<int>('intermediary_id') == brokerB)
+          .map((r) => r.read<double>('quantity')).toList()..sort();
+      expect(aQtys, [12.0, 15.0, 20.0], reason: 'Broker A wiped and replaced with NEW quantities');
+      expect(bQtys, [4.0, 7.0],         reason: 'Broker B untouched');
+    });
+
+    test('same ISIN at two intermediaries produces two independent asset rows', () async {
+      final brokerA = await db.into(db.intermediaries).insert(
+        IntermediariesCompanion.insert(name: 'Broker A'),
+      );
+      final brokerB = await db.into(db.intermediaries).insert(
+        IntermediariesCompanion.insert(name: 'Broker B'),
+      );
+
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['IE00B4L5Y983', '10', '100', 'EUR', '1000'],
+        ]),
+        mappings: spotMappings, baseCurrency: 'EUR',
+        intermediaryId: brokerA,
+      );
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['IE00B4L5Y983', '5', '100', 'EUR', '500'],
+        ]),
+        mappings: spotMappings, baseCurrency: 'EUR',
+        intermediaryId: brokerB,
+      );
+
+      final assets = await (db.select(db.assets)..where((a) => a.isin.equals('IE00B4L5Y983'))).get();
+      expect(assets.length, 2, reason: 'one asset row per (ISIN, intermediary)');
+      final byBroker = {for (final a in assets) a.intermediaryId: a.id};
+      expect(byBroker.keys.toSet(), {brokerA, brokerB});
+
+      final eventsA = await (db.select(db.assetEvents)..where((e) => e.assetId.equals(byBroker[brokerA]!))).get();
+      final eventsB = await (db.select(db.assetEvents)..where((e) => e.assetId.equals(byBroker[brokerB]!))).get();
+      expect(eventsA.map((e) => e.quantity), [10.0]);
+      expect(eventsB.map((e) => e.quantity), [5.0]);
+
+      // Re-importing Broker A must not touch Broker B.
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['IE00B4L5Y983', '99', '110', 'EUR', '10890'],
+        ]),
+        mappings: spotMappings, baseCurrency: 'EUR',
+        intermediaryId: brokerA,
+      );
+      final eventsAAfter = await (db.select(db.assetEvents)..where((e) => e.assetId.equals(byBroker[brokerA]!))).get();
+      final eventsBAfter = await (db.select(db.assetEvents)..where((e) => e.assetId.equals(byBroker[brokerB]!))).get();
+      expect(eventsAAfter.map((e) => e.quantity), [99.0]);
+      expect(eventsBAfter.map((e) => e.quantity), [5.0]);
     });
   });
 

--- a/test/import_service_test.dart
+++ b/test/import_service_test.dart
@@ -8,7 +8,6 @@ import 'package:finance_copilot/database/database.dart';
 import 'package:finance_copilot/database/tables.dart';
 import 'package:finance_copilot/services/import_service.dart';
 import 'package:finance_copilot/services/isin_lookup_service.dart';
-import 'package:finance_copilot/utils/amount_parser.dart' as amt;
 
 void main() {
   late AppDatabase db;
@@ -246,6 +245,7 @@ Date,Amount
           const ColumnMapping(sourceColumn: 'Amount', targetField: 'amount'),
         ],
         accountId: accountId,
+        appLocale: 'it_IT',
       );
       final tx = (await db.select(db.transactions).get()).first;
       expect(tx.amount, 1234.56);
@@ -319,35 +319,7 @@ Date,Amount
     });
   });
 
-  group('Amount parser', () {
-    test('standard decimal values', () {
-      expect(amt.parseAmount('260.44'), 260.44);
-      expect(amt.parseAmount('1.5'), 1.5);
-      expect(amt.parseAmount('12.34'), 12.34);
-    });
-
-    test('3 decimal places from XLSX (was bug: treated as thousands)', () {
-      // After XLSX fix, these arrive as "260.4370" (4 digits) and are parsed correctly.
-      // But even without XLSX fix, parseAmount should handle them:
-      expect(amt.parseAmount('260.4370'), closeTo(260.437, 0.0001));
-      expect(amt.parseAmount('238.7110'), closeTo(238.711, 0.0001));
-    });
-
-    test('European thousands with dot', () {
-      expect(amt.parseAmount('1.234'), 1234.0);
-      expect(amt.parseAmount('1.234.567'), 1234567.0);
-    });
-
-    test('European decimal with comma', () {
-      expect(amt.parseAmount('260,44'), 260.44);
-      expect(amt.parseAmount('1,5'), 1.5);
-    });
-
-    test('European thousands + decimal', () {
-      expect(amt.parseAmount('1.234,56'), 1234.56);
-      expect(amt.parseAmount('1,234.56'), 1234.56);
-    });
-  });
+  // Locale-aware parser tests live in test/amount_parser_test.dart.
 
   group('Asset event import', () {
     FilePreview makeAssetPreview(List<List<String>> rows) {
@@ -1109,6 +1081,138 @@ Date,Amount
       expect(txs.length, 2);
       expect(txs[0].balanceAfter, 500.0);
       expect(txs[1].balanceAfter, 300.0);
+    });
+  });
+
+  group('Number-locale persistence and resolution (issue #60)', () {
+    FilePreview makeSpotPreview(List<List<String>> rows) {
+      return FilePreview(
+        columns: ['isin', 'quantity', 'price', 'currency', 'amount'],
+        rows: rows.map((r) => {
+          'isin': r[0], 'quantity': r[1], 'price': r[2],
+          'currency': r[3], 'amount': r[4],
+        }).toList(),
+        totalRows: rows.length,
+      );
+    }
+
+    const spotMappings = [
+      ColumnMapping(sourceColumn: 'isin', targetField: 'isin'),
+      ColumnMapping(sourceColumn: 'quantity', targetField: 'quantity'),
+      ColumnMapping(sourceColumn: 'price', targetField: 'price'),
+      ColumnMapping(sourceColumn: 'currency', targetField: 'currency'),
+      ColumnMapping(sourceColumn: 'amount', targetField: 'amount'),
+    ];
+
+    test('issue #60 — Italian "80,000" / "81,050" parsed as 80 / 81.05', () async {
+      // The literal #60 scenario: Sella XLSX certificate row with
+      // Italian-locale 3-decimal display.
+      final intId = await db.into(db.intermediaries).insert(
+        IntermediariesCompanion.insert(name: 'Broker IT'),
+      );
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['XS3209104044', '80,000', '81,050', 'EUR', '6.484,00'],
+        ]),
+        mappings: spotMappings,
+        baseCurrency: 'EUR',
+        intermediaryId: intId,
+        appLocale: 'it_IT',
+      );
+      final events = await db.select(db.assetEvents).get();
+      expect(events.length, 1);
+      expect(events.first.quantity, 80.0);
+      expect(events.first.price, closeTo(81.05, 1e-9));
+      expect(events.first.amount, closeTo(6484.0, 1e-9));
+    });
+
+    test('per-intermediary override is persisted and reused', () async {
+      final intId = await db.into(db.intermediaries).insert(
+        IntermediariesCompanion.insert(name: 'Broker A'),
+      );
+
+      // First import: user explicitly picks en_US.
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['IE00B4L5Y983', '10', '100', 'EUR', '1000'],
+        ]),
+        mappings: spotMappings,
+        baseCurrency: 'EUR',
+        intermediaryId: intId,
+        numberLocaleOverride: 'en_US',
+        appLocale: 'it_IT',
+      );
+
+      // Override should be persisted on the intermediary.
+      final inter = await (db.select(db.intermediaries)
+            ..where((i) => i.id.equals(intId)))
+          .getSingle();
+      expect(inter.defaultImportLocale, 'en_US');
+
+      // Second import without override: parses under saved 'en_US',
+      // not the app locale 'it_IT'. "1,000" is one thousand under en_US.
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['IE00B4L5Y983', '1,000', '100', 'EUR', '100000'],
+        ]),
+        mappings: spotMappings,
+        baseCurrency: 'EUR',
+        intermediaryId: intId,
+        appLocale: 'it_IT',
+      );
+      final events = await db.select(db.assetEvents).get();
+      // Last event reflects the en_US parse.
+      final last = events.last;
+      expect(last.quantity, 1000.0);
+    });
+
+    test('per-account override is persisted on ImportConfigs', () async {
+      final accountId = await db.into(db.accounts).insert(
+        AccountsCompanion.insert(name: 'Test'),
+      );
+      final tempDir2 = await Directory.systemTemp.createTemp('fc_locale_');
+      addTearDown(() async => await tempDir2.delete(recursive: true));
+      final f = File('${tempDir2.path}/tx.csv')
+        ..writeAsStringSync('Date,Amount\n01/01/2024,"1.234,56"\n');
+      final preview = await importer.parseFile(f.path);
+      await importer.importTransactions(
+        preview: preview,
+        mappings: [
+          const ColumnMapping(sourceColumn: 'Date', targetField: 'date'),
+          const ColumnMapping(sourceColumn: 'Amount', targetField: 'amount'),
+        ],
+        accountId: accountId,
+        numberLocaleOverride: 'it_IT',
+        appLocale: 'en_US',
+      );
+      final cfg = await (db.select(db.importConfigs)
+            ..where((c) => c.accountId.equals(accountId)))
+          .getSingle();
+      expect(cfg.numberLocale, 'it_IT');
+      final tx = (await db.select(db.transactions).get()).first;
+      expect(tx.amount, closeTo(1234.56, 1e-9));
+    });
+
+    test('appLocale fallback when no override and no saved value', () async {
+      final intId = await db.into(db.intermediaries).insert(
+        IntermediariesCompanion.insert(name: 'Broker NoOverride'),
+      );
+      await importer.importAssetEventsGrouped(
+        preview: makeSpotPreview([
+          ['IE00B4L5Y983', '5.000', '100', 'EUR', '500.000'],
+        ]),
+        mappings: spotMappings,
+        baseCurrency: 'EUR',
+        intermediaryId: intId,
+        appLocale: 'it_IT', // 5.000 is 5000 under it_IT
+      );
+      final events = await db.select(db.assetEvents).get();
+      expect(events.first.quantity, 5000.0);
+      // No override given → defaultImportLocale stays NULL.
+      final inter = await (db.select(db.intermediaries)
+            ..where((i) => i.id.equals(intId)))
+          .getSingle();
+      expect(inter.defaultImportLocale, isNull);
     });
   });
 }

--- a/test/intermediary_service_test.dart
+++ b/test/intermediary_service_test.dart
@@ -117,27 +117,24 @@ void main() {
       expect(account.intermediaryId, isNull);
     });
 
-    test('unlinks assets when intermediary is deleted', () async {
+    test('refuses to delete an intermediary that still has assets', () async {
       final intId = await service.create(name: 'Broker A');
 
-      // Create an asset linked to the intermediary
-      final assetId = await db.into(db.assets).insert(
+      await db.into(db.assets).insert(
         AssetsCompanion.insert(
           name: 'ETF World',
           assetType: AssetType.stockEtf,
           valuationMethod: ValuationMethod.marketPrice,
-          intermediaryId: Value(intId),
+          intermediaryId: intId,
         ),
       );
 
-      // Delete the intermediary
-      await service.delete(intId);
-
-      // Asset should still exist but with null intermediaryId
-      final asset = await (db.select(db.assets)
-            ..where((a) => a.id.equals(assetId)))
-          .getSingle();
-      expect(asset.intermediaryId, isNull);
+      // Assets must always have an intermediary (schema v29), so deletion
+      // refuses until the user moves the assets elsewhere.
+      expect(
+        () => service.delete(intId),
+        throwsA(isA<StateError>()),
+      );
     });
   });
 
@@ -213,12 +210,14 @@ void main() {
 
   group('moveAsset', () {
     test('assigns an asset to an intermediary', () async {
+      final defaultInt = await service.create(name: 'Default');
       final intId = await service.create(name: 'Broker A');
       final assetId = await db.into(db.assets).insert(
         AssetsCompanion.insert(
           name: 'ETF World',
           assetType: AssetType.stockEtf,
           valuationMethod: ValuationMethod.marketPrice,
+          intermediaryId: defaultInt,
         ),
       );
 
@@ -230,25 +229,6 @@ void main() {
       expect(asset.intermediaryId, intId);
     });
 
-    test('unassigns an asset from an intermediary', () async {
-      final intId = await service.create(name: 'Broker A');
-      final assetId = await db.into(db.assets).insert(
-        AssetsCompanion.insert(
-          name: 'ETF World',
-          assetType: AssetType.stockEtf,
-          valuationMethod: ValuationMethod.marketPrice,
-          intermediaryId: Value(intId),
-        ),
-      );
-
-      await service.moveAsset(assetId, null);
-
-      final asset = await (db.select(db.assets)
-            ..where((a) => a.id.equals(assetId)))
-          .getSingle();
-      expect(asset.intermediaryId, isNull);
-    });
-
     test('moves asset from one intermediary to another', () async {
       final intId1 = await service.create(name: 'Broker A');
       final intId2 = await service.create(name: 'Broker B');
@@ -257,7 +237,7 @@ void main() {
           name: 'ETF World',
           assetType: AssetType.stockEtf,
           valuationMethod: ValuationMethod.marketPrice,
-          intermediaryId: Value(intId1),
+          intermediaryId: intId1,
         ),
       );
 

--- a/test/market_price_service_test.dart
+++ b/test/market_price_service_test.dart
@@ -8,10 +8,12 @@ import 'package:finance_copilot/services/investing_com_service.dart';
 void main() {
   late AppDatabase db;
   late InvestingComService service;
+  late int iid;
 
-  setUp(() {
+  setUp(() async {
     db = AppDatabase.forTesting(NativeDatabase.memory());
     service = InvestingComService(db);
+    iid = await db.into(db.intermediaries).insert(IntermediariesCompanion.insert(name: 'Default'));
   });
 
   tearDown(() async => await db.close());
@@ -23,11 +25,13 @@ void main() {
         name: 'Asset A',
         assetType: AssetType.stockEtf,
         valuationMethod: ValuationMethod.marketPrice,
+        intermediaryId: iid,
       ));
       final asset2Id = await db.into(db.assets).insert(AssetsCompanion.insert(
         name: 'Asset B',
         assetType: AssetType.stockEtf,
         valuationMethod: ValuationMethod.marketPrice,
+        intermediaryId: iid,
       ));
 
       // Insert 3 prices for asset1

--- a/test/offline_first_test.dart
+++ b/test/offline_first_test.dart
@@ -11,11 +11,13 @@ void main() {
   late AppDatabase db;
   late InvestingComService priceService;
   late ExchangeRateService rateService;
+  late int iid;
 
-  setUp(() {
+  setUp(() async {
     db = AppDatabase.forTesting(NativeDatabase.memory());
     priceService = InvestingComService(db);
     rateService = ExchangeRateService(db);
+    iid = await db.into(db.intermediaries).insert(IntermediariesCompanion.insert(name: 'Default'));
   });
 
   tearDown(() async => await db.close());
@@ -54,6 +56,7 @@ void main() {
       valuationMethod: ValuationMethod.marketPrice,
       ticker: Value(ticker),
       currency: Value(currency),
+      intermediaryId: iid,
     ));
   }
 
@@ -184,13 +187,13 @@ void main() {
   });
 
   group('DB merge column intersection', () {
-    test('schema version is 28 after legacy table cleanup', () async {
-      // v27 added ExtraordinaryEvents; v28 dropped the legacy CAPEX and
-      // IncomeAdjustment tables, renamed buffers.linked_depreciation_id,
-      // and dropped transactions.depreciation_id.
+    test('schema version is 29 after assets.intermediary_id NOT NULL migration', () async {
+      // v27 added ExtraordinaryEvents; v28 dropped legacy CAPEX/IncomeAdj
+      // and their FK plumbing; v29 backfilled NULL asset.intermediary_id to
+      // a "Default" intermediary and enforces the column non-null in Dart.
       final rows = await db.customSelect('PRAGMA user_version').get();
       final version = rows.first.read<int>('user_version');
-      expect(version, 28);
+      expect(version, 29);
     });
 
     test('accounts table has no ghost columns', () async {
@@ -291,6 +294,7 @@ void main() {
         assetClass: const Value(AssetClass.fixedIncome),
         valuationMethod: ValuationMethod.marketPrice,
         currency: Value(currency),
+        intermediaryId: iid,
       ));
     }
 

--- a/test/offline_first_test.dart
+++ b/test/offline_first_test.dart
@@ -187,13 +187,14 @@ void main() {
   });
 
   group('DB merge column intersection', () {
-    test('schema version is 29 after assets.intermediary_id NOT NULL migration', () async {
+    test('schema version is 30 after number-locale columns added', () async {
       // v27 added ExtraordinaryEvents; v28 dropped legacy CAPEX/IncomeAdj
       // and their FK plumbing; v29 backfilled NULL asset.intermediary_id to
-      // a "Default" intermediary and enforces the column non-null in Dart.
+      // a "Default" intermediary; v30 added per-source number-format locale
+      // columns to import_configs and intermediaries.
       final rows = await db.customSelect('PRAGMA user_version').get();
       final version = rows.first.read<int>('user_version');
-      expect(version, 29);
+      expect(version, 30);
     });
 
     test('accounts table has no ghost columns', () async {


### PR DESCRIPTION
## Summary
Large accumulation of work on top of v0.6.0. Headline changes:

- **Import fixes (schema v29–v30)**
  - Fix #60 — schema v30: locale-aware amount parsing (Auto / it_IT / en_US / en_GB / de_DE / fr_FR / es_ES) persisted per-source (intermediary / import config).
  - Fix #61 — schema v29: every asset belongs to exactly one intermediary; eliminates the "unassigned asset" bug that accumulated events across spot imports.
  - Fix import preview using stale stored `balance_after`.
  - Fix filtered-mode pre-cutoff balance for Revolut-style imports.
- **Drive sync rewrite** — auto-sync removed; replaced with explicit **Backup / Restore** buttons in Settings → Import/Export (fixes several data-loss incidents from silent push/pull/poll).
- **Schema v27/v28 — ExtraordinaryEvents**
  - New unified events schema with CAPEX + IncomeAdjustment backfill.
  - Legacy CAPEX and IncomeAdjustment tables/services/screens dropped at v28.
- **UI restructure** — consolidated 5 → 3 top-level nav destinations; AccountsScreen tabbed (Accounts / Income / Adjustments); unified Event edit/detail screens.
- **Asset detail charts** — value (invested + market) and price history.
- **CI / test improvements** — `SLOW_TESTS` flag, updated integration tests, removed unused Claude Code Review workflow.

## Test plan
- [x] `flutter test` — 450 unit tests green locally
- [x] Asset import integration tests green locally (5/5)
- [ ] `flutter test integration_test/all_tests.dart -d macos`
- [ ] `flutter test integration_test/live_data_fetch_test.dart -d macos`
- [ ] Manual smoke on macOS (dev build)
- [ ] Manual smoke on Android emulator
- [ ] Manual smoke on Windows VM