### PR TITLE
Add zoom math helpers and enhance multi-gesture chart interactions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,9 @@
       "Bash(dart run *)",
       "Bash(dart analyze *)",
       "Bash(grep -v \"^Analyzing\\\\|^$\\\\|packages have newer\")",
-      "Bash(flutter test *)"
+      "Bash(flutter test *)",
+      "Bash(mkdir -p /root/.claude/plans)",
+      "Read(//root/.claude/plans/**)"
     ],
     "defaultMode": "bypassPermissions"
   },

--- a/lib/ui/screens/dashboard/chart_card.dart
+++ b/lib/ui/screens/dashboard/chart_card.dart
@@ -213,6 +213,7 @@ class _ChartCard extends ConsumerWidget {
                       xMax: zoomMaxX ?? (totalSpots.isNotEmpty ? totalSpots.last.x : 1),
                       yMin: effectiveMinY,
                       yMax: effectiveMaxY,
+                      totalDays: totalSpots.isNotEmpty ? totalSpots.last.x : 1,
                       firstDate: allData.firstDate,
                       baseCurrency: allData.baseCurrency,
                       locale: locale,

--- a/lib/ui/screens/dashboard/dashboard_screen.dart
+++ b/lib/ui/screens/dashboard/dashboard_screen.dart
@@ -6,8 +6,9 @@ import 'dart:ui';
 import '../../../build_flags.dart';
 
 import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show Clipboard, ClipboardData;
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:drift/drift.dart' show OrderingTerm, Variable;

--- a/lib/ui/screens/dashboard/unified_chart.dart
+++ b/lib/ui/screens/dashboard/unified_chart.dart
@@ -27,7 +27,69 @@ class DashedLinePainter extends CustomPainter {
 }
 
 // ════════════════════════════════════════════════════
-// Drag-to-zoom wrapper (CloudWatch style)
+// Zoom math helpers (file-local, unit-tested)
+// ════════════════════════════════════════════════════
+
+/// Compute a new X window after zooming and/or panning, anchored at the
+/// focal pixel. Result is clamped to `[0, totalDays]`. When the resulting
+/// span would meet or exceed `totalDays`, the full data range is returned.
+({double minX, double maxX}) computeZoomedXRange({
+  required double currentMinX,
+  required double currentMaxX,
+  required double focalPx,
+  required double leftReserved,
+  required double chartWidth,
+  required double scaleFactor,
+  required double panPx,
+  required double totalDays,
+}) {
+  final currentRange = currentMaxX - currentMinX;
+  final pxFromLeft = focalPx - leftReserved;
+  final focalChartX = currentMinX + pxFromLeft / chartWidth * currentRange;
+
+  var newRange = currentRange / scaleFactor;
+  if (newRange >= totalDays) return (minX: 0, maxX: totalDays);
+  if (newRange < 1) newRange = 1;
+
+  var newMinX = focalChartX - pxFromLeft / chartWidth * newRange - panPx * (newRange / chartWidth);
+  var newMaxX = newMinX + newRange;
+
+  if (newMinX < 0) {
+    newMinX = 0;
+    newMaxX = newRange;
+  }
+  if (newMaxX > totalDays) {
+    newMaxX = totalDays;
+    newMinX = totalDays - newRange;
+  }
+  return (minX: newMinX, maxX: newMaxX);
+}
+
+/// Compute a new Y window after zooming and/or panning, anchored at the
+/// focal pixel. Y axis is inverted vs pixels (pixel 0 = top = max Y).
+/// Y has no clamping — chart data may legitimately extend beyond the
+/// current zoom window.
+({double minY, double maxY}) computeZoomedYRange({
+  required double currentMinY,
+  required double currentMaxY,
+  required double focalPy,
+  required double chartHeight,
+  required double scaleFactor,
+  required double panPy,
+}) {
+  final currentRange = currentMaxY - currentMinY;
+  final fractionFromBottom = 1.0 - focalPy / chartHeight;
+  final focalChartY = currentMinY + fractionFromBottom * currentRange;
+
+  final newRange = currentRange / scaleFactor;
+  final dyUnits = panPy * (newRange / chartHeight);
+  final newMinY = focalChartY - fractionFromBottom * newRange + dyUnits;
+  final newMaxY = newMinY + newRange;
+  return (minY: newMinY, maxY: newMaxY);
+}
+
+// ════════════════════════════════════════════════════
+// Drag/pinch/pan/wheel zoom wrapper
 // ════════════════════════════════════════════════════
 
 class DragZoomWrapper extends StatefulWidget {
@@ -36,6 +98,7 @@ class DragZoomWrapper extends StatefulWidget {
   final double xMax;
   final double yMin;
   final double yMax;
+  final double totalDays;
   final double leftReserved = 60;
   final double bottomReserved = 28;
   final DateTime firstDate;
@@ -43,12 +106,13 @@ class DragZoomWrapper extends StatefulWidget {
   final String locale;
   final void Function(double? minX, double? maxX, double? minY, double? maxY) onZoom;
 
-  const DragZoomWrapper({super.key, 
+  const DragZoomWrapper({super.key,
     required this.child,
     required this.xMin,
     required this.xMax,
     this.yMin = 0,
     this.yMax = 1,
+    required this.totalDays,
     required this.firstDate,
     required this.baseCurrency,
     required this.locale,
@@ -63,6 +127,12 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
   Offset? _dragStart;
   Offset? _dragCurrent;
   bool _isDragging = false;
+  bool _panning = false;
+  PointerDeviceKind? _activeKind;
+
+  double? _scaleStartMinX;
+  double? _scaleStartMaxX;
+  double? _scaleStartFocalChartX;
 
   double _pixelToChartX(double px, double chartWidth) {
     final fraction = (px - widget.leftReserved) / chartWidth;
@@ -73,6 +143,126 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
     // Y is inverted: top of widget = max Y, bottom of chart area = min Y
     final fraction = 1.0 - (py / chartHeight);
     return widget.yMin + fraction * (widget.yMax - widget.yMin);
+  }
+
+  bool get _isZoomedX => (widget.xMax - widget.xMin) < widget.totalDays - 1e-6;
+  bool get _isZoomedY => (widget.yMax - widget.yMin) > 0;
+
+  void _resetTransientState() {
+    _dragStart = null;
+    _dragCurrent = null;
+    _isDragging = false;
+    _panning = false;
+    _activeKind = null;
+  }
+
+  void _handleMousePan(PointerMoveEvent e, double chartWidth, double chartHeight) {
+    final xRange = widget.xMax - widget.xMin;
+    final yRange = widget.yMax - widget.yMin;
+    if (xRange <= 0 || chartWidth <= 0) return;
+
+    final dxUnits = e.delta.dx * xRange / chartWidth;
+    var newMinX = widget.xMin - dxUnits;
+    var newMaxX = widget.xMax - dxUnits;
+    if (newMinX < 0) {
+      newMinX = 0;
+      newMaxX = xRange;
+    }
+    if (newMaxX > widget.totalDays) {
+      newMaxX = widget.totalDays;
+      newMinX = widget.totalDays - xRange;
+    }
+
+    double? newMinY, newMaxY;
+    if (yRange > 0 && chartHeight > 0) {
+      // Y is inverted: dragging the mouse down should shift the visible
+      // window DOWN as well, so we add dy.
+      final dyUnits = e.delta.dy * yRange / chartHeight;
+      newMinY = widget.yMin + dyUnits;
+      newMaxY = widget.yMax + dyUnits;
+    }
+    widget.onZoom(newMinX, newMaxX, newMinY, newMaxY);
+  }
+
+  void _handleWheelZoom(PointerScrollEvent sig, double chartWidth, double chartHeight) {
+    if (chartWidth <= 0) return;
+    final shift = HardwareKeyboard.instance.isShiftPressed;
+    final factor = exp(-sig.scrollDelta.dy * 0.0015);
+
+    if (!shift) {
+      final r = computeZoomedXRange(
+        currentMinX: widget.xMin,
+        currentMaxX: widget.xMax,
+        focalPx: sig.localPosition.dx,
+        leftReserved: widget.leftReserved,
+        chartWidth: chartWidth,
+        scaleFactor: factor,
+        panPx: 0,
+        totalDays: widget.totalDays,
+      );
+      final stillZoomedY = _isZoomedY;
+      if (r.minX <= 0 && r.maxX >= widget.totalDays - 1e-6) {
+        widget.onZoom(null, null, stillZoomedY ? widget.yMin : null, stillZoomedY ? widget.yMax : null);
+      } else {
+        widget.onZoom(r.minX, r.maxX, stillZoomedY ? widget.yMin : null, stillZoomedY ? widget.yMax : null);
+      }
+      return;
+    }
+
+    if (!_isZoomedY || chartHeight <= 0) return;
+    final r = computeZoomedYRange(
+      currentMinY: widget.yMin,
+      currentMaxY: widget.yMax,
+      focalPy: sig.localPosition.dy,
+      chartHeight: chartHeight,
+      scaleFactor: factor,
+      panPy: 0,
+    );
+    widget.onZoom(widget.xMin, widget.xMax, r.minY, r.maxY);
+  }
+
+  void _onScaleStart(ScaleStartDetails d, double chartWidth) {
+    if (_activeKind == PointerDeviceKind.mouse || chartWidth <= 0) return;
+    _scaleStartMinX = widget.xMin;
+    _scaleStartMaxX = widget.xMax;
+    final pxToUnits = (widget.xMax - widget.xMin) / chartWidth;
+    _scaleStartFocalChartX =
+        widget.xMin + (d.localFocalPoint.dx - widget.leftReserved) * pxToUnits;
+  }
+
+  void _onScaleUpdate(ScaleUpdateDetails d, double chartWidth) {
+    if (_scaleStartMinX == null || chartWidth <= 0) return;
+
+    final isPinch = d.pointerCount >= 2;
+    if (!isPinch && !_isZoomedX) return; // let parent vertical scroll keep this gesture
+
+    final startRange = _scaleStartMaxX! - _scaleStartMinX!;
+    var newRange = startRange / d.scale;
+    if (newRange >= widget.totalDays) {
+      widget.onZoom(null, null, null, null);
+      return;
+    }
+    if (newRange < 1) newRange = 1;
+
+    final focalPxFromLeft = d.localFocalPoint.dx - widget.leftReserved;
+    var newMinX = _scaleStartFocalChartX! - focalPxFromLeft / chartWidth * newRange;
+    var newMaxX = newMinX + newRange;
+
+    if (newMinX < 0) {
+      newMinX = 0;
+      newMaxX = newRange;
+    }
+    if (newMaxX > widget.totalDays) {
+      newMaxX = widget.totalDays;
+      newMinX = newMaxX - newRange;
+    }
+    widget.onZoom(newMinX, newMaxX, null, null);
+  }
+
+  void _onScaleEnd(ScaleEndDetails _) {
+    _scaleStartMinX = null;
+    _scaleStartMaxX = null;
+    _scaleStartFocalChartX = null;
   }
 
   @override
@@ -87,14 +277,22 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
         return Listener(
           behavior: HitTestBehavior.translucent,
           onPointerDown: (e) {
+            _activeKind = e.kind;
+            if (e.kind != PointerDeviceKind.mouse) return;
+            final shift = HardwareKeyboard.instance.isShiftPressed;
             setState(() {
               _dragStart = e.localPosition;
               _dragCurrent = e.localPosition;
               _isDragging = false;
+              _panning = shift;
             });
           },
           onPointerMove: (e) {
-            if (_dragStart == null) return;
+            if (_activeKind != PointerDeviceKind.mouse || _dragStart == null) return;
+            if (_panning) {
+              _handleMousePan(e, chartWidth, chartHeight);
+              return;
+            }
             final dist = (e.localPosition - _dragStart!).distance;
             if (dist > 5) _isDragging = true;
             if (_isDragging) {
@@ -102,6 +300,14 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
             }
           },
           onPointerUp: (e) {
+            if (_activeKind != PointerDeviceKind.mouse) {
+              setState(_resetTransientState);
+              return;
+            }
+            if (_panning) {
+              setState(_resetTransientState);
+              return;
+            }
             if (_isDragging && _dragStart != null && _dragCurrent != null) {
               final x1 = _pixelToChartX(_dragStart!.dx, chartWidth);
               final x2 = _pixelToChartX(_dragCurrent!.dx, chartWidth);
@@ -129,19 +335,40 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
                 widget.onZoom(newMinX ?? widget.xMin, newMaxX ?? widget.xMax, newMinY, newMaxY);
               }
             }
-            setState(() {
-              _dragStart = null;
-              _dragCurrent = null;
-              _isDragging = false;
-            });
+            setState(_resetTransientState);
           },
-          child: GestureDetector(
+          onPointerCancel: (_) {
+            setState(_resetTransientState);
+          },
+          onPointerSignal: (sig) {
+            if (sig is PointerScrollEvent) {
+              _handleWheelZoom(sig, chartWidth, chartHeight);
+            }
+          },
+          child: RawGestureDetector(
             behavior: HitTestBehavior.translucent,
-            onDoubleTap: () => widget.onZoom(null, null, null, null),
-            child: Stack(
-              children: [
-                widget.child,
-                if (_isDragging && _dragStart != null && _dragCurrent != null)
+            gestures: <Type, GestureRecognizerFactory>{
+              ScaleGestureRecognizer:
+                  GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
+                () => ScaleGestureRecognizer(
+                  supportedDevices: const {
+                    PointerDeviceKind.touch,
+                    PointerDeviceKind.stylus,
+                  },
+                ),
+                (r) => r
+                  ..onStart = (d) => _onScaleStart(d, chartWidth)
+                  ..onUpdate = (d) => _onScaleUpdate(d, chartWidth)
+                  ..onEnd = _onScaleEnd,
+              ),
+            },
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onDoubleTap: () => widget.onZoom(null, null, null, null),
+              child: Stack(
+                children: [
+                  widget.child,
+                  if (_isDragging && !_panning && _dragStart != null && _dragCurrent != null)
                   Positioned(
                     left: min(_dragStart!.dx, _dragCurrent!.dx),
                     top: min(_dragStart!.dy, _dragCurrent!.dy),
@@ -171,7 +398,8 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
                       ),
                     ),
                   ),
-              ],
+                ],
+              ),
             ),
           ),
         );

--- a/test/ui/dashboard/zoom_math_test.dart
+++ b/test/ui/dashboard/zoom_math_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:finance_copilot/ui/screens/dashboard/dashboard_screen.dart';
+
+void main() {
+  group('computeZoomedXRange', () {
+    test('zooming 2x at centered focal halves the range and stays centered', () {
+      final r = computeZoomedXRange(
+        currentMinX: 0,
+        currentMaxX: 100,
+        focalPx: 460, // leftReserved=60 + 0.5 * chartWidth=800 → 50% across
+        leftReserved: 60,
+        chartWidth: 800,
+        scaleFactor: 2,
+        panPx: 0,
+        totalDays: 100,
+      );
+      expect(r.minX, closeTo(25, 1e-9));
+      expect(r.maxX, closeTo(75, 1e-9));
+    });
+
+    test('zooming at a left-biased focal pulls the window toward that focal', () {
+      // Focal at 25% of chart width: 60 + 0.25 * 800 = 260.
+      final r = computeZoomedXRange(
+        currentMinX: 0,
+        currentMaxX: 100,
+        focalPx: 260,
+        leftReserved: 60,
+        chartWidth: 800,
+        scaleFactor: 2,
+        panPx: 0,
+        totalDays: 100,
+      );
+      // focalChartX = 25; new range = 50; minX = 25 - 0.25*50 = 12.5
+      expect(r.minX, closeTo(12.5, 1e-9));
+      expect(r.maxX, closeTo(62.5, 1e-9));
+    });
+
+    test('panPx shifts both bounds by the same amount (no scale change)', () {
+      // No zoom factor, but currentRange is below totalDays so panPx applies.
+      final r = computeZoomedXRange(
+        currentMinX: 25,
+        currentMaxX: 75,
+        focalPx: 460,
+        leftReserved: 60,
+        chartWidth: 800,
+        scaleFactor: 1,
+        panPx: 20,
+        totalDays: 100,
+      );
+      // dxUnits = 20 * 50/800 = 1.25; both bounds shift down by 1.25.
+      expect(r.minX, closeTo(23.75, 1e-9));
+      expect(r.maxX, closeTo(73.75, 1e-9));
+      expect(r.maxX - r.minX, closeTo(50, 1e-9));
+    });
+
+    test('panning past the left edge clamps to 0 and preserves the span', () {
+      final r = computeZoomedXRange(
+        currentMinX: 25,
+        currentMaxX: 75,
+        focalPx: 460,
+        leftReserved: 60,
+        chartWidth: 800,
+        scaleFactor: 1,
+        panPx: 50000,
+        totalDays: 100,
+      );
+      expect(r.minX, 0);
+      expect(r.maxX, closeTo(50, 1e-9));
+    });
+
+    test('panning past the right edge clamps to totalDays and preserves the span', () {
+      final r = computeZoomedXRange(
+        currentMinX: 25,
+        currentMaxX: 75,
+        focalPx: 460,
+        leftReserved: 60,
+        chartWidth: 800,
+        scaleFactor: 1,
+        panPx: -50000,
+        totalDays: 100,
+      );
+      expect(r.maxX, 100);
+      expect(r.minX, closeTo(50, 1e-9));
+    });
+
+    test('zooming further out than totalDays returns the full range', () {
+      final r = computeZoomedXRange(
+        currentMinX: 25,
+        currentMaxX: 75,
+        focalPx: 460,
+        leftReserved: 60,
+        chartWidth: 800,
+        scaleFactor: 0.1,
+        panPx: 0,
+        totalDays: 100,
+      );
+      expect(r.minX, 0);
+      expect(r.maxX, 100);
+    });
+  });
+
+  group('computeZoomedYRange', () {
+    test('zooming 2x at centered focal halves the range and stays centered', () {
+      final r = computeZoomedYRange(
+        currentMinY: 0,
+        currentMaxY: 100,
+        focalPy: 300, // chartHeight=600 → fraction-from-bottom 0.5
+        chartHeight: 600,
+        scaleFactor: 2,
+        panPy: 0,
+      );
+      expect(r.minY, closeTo(25, 1e-9));
+      expect(r.maxY, closeTo(75, 1e-9));
+    });
+
+    test('positive panPy (mouse down) shifts the window up in chart units', () {
+      final r = computeZoomedYRange(
+        currentMinY: 25,
+        currentMaxY: 75,
+        focalPy: 300,
+        chartHeight: 600,
+        scaleFactor: 1,
+        panPy: 12,
+      );
+      // dyUnits = 12 * 50/600 = 1.0
+      expect(r.minY, closeTo(26, 1e-9));
+      expect(r.maxY, closeTo(76, 1e-9));
+    });
+
+    test('Y has no clamping', () {
+      final r = computeZoomedYRange(
+        currentMinY: 0,
+        currentMaxY: 100,
+        focalPy: 300,
+        chartHeight: 600,
+        scaleFactor: 1,
+        panPy: 100000,
+      );
+      // Far-pan moves the window up freely; no upper clamp.
+      expect(r.minY, greaterThan(1000));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Refactored and enhanced the chart zoom/pan interaction system by extracting zoom mathematics into testable helper functions and adding support for mouse wheel scrolling, shift+drag panning, and touch pinch gestures.

## Key Changes

- **Extracted zoom math helpers**: Created `computeZoomedXRange()` and `computeZoomedYRange()` as pure, unit-testable functions that handle zoom and pan calculations with proper clamping and edge case handling
  - X-axis: clamped to `[0, totalDays]`, returns full range when zoomed out beyond data bounds
  - Y-axis: unclamped to allow legitimate chart data beyond current window
  - Both support focal-point anchoring and pan offsets

- **Added comprehensive test coverage**: New `zoom_math_test.dart` with 9 test cases covering centered zoom, biased focal points, panning edge cases, and boundary conditions

- **Enhanced gesture support**:
  - Mouse wheel zoom (Shift+wheel for Y-axis zoom)
  - Shift+drag for panning when zoomed
  - Touch pinch-to-zoom via `ScaleGestureRecognizer`
  - Proper pointer device kind tracking to avoid conflicts between input methods

- **Improved state management**:
  - Added `_resetTransientState()` helper to consistently clear drag/pan state
  - Track active pointer device kind to prevent cross-device gesture interference
  - Separate `_panning` flag to distinguish pan mode from selection drag

- **Updated component signatures**: Added `totalDays` parameter to `DragZoomWrapper` to enable proper range clamping

## Implementation Details

- Zoom calculations anchor at the focal point (mouse/touch position) to maintain intuitive interaction
- Pan operations respect data boundaries with smooth clamping
- Y-axis panning inverts pixel coordinates (pixel 0 = top = max Y value)
- Gesture recognition uses `RawGestureDetector` for touch/stylus pinch while maintaining mouse drag selection
- Double-tap continues to reset zoom to full range

https://claude.ai/code/session_01QtvWSTquHSTkXtUBEySwaA