### PR TITLE
Fix chart zoom/pan UX regressions on desktop and mobile

### DIFF
--- a/lib/ui/screens/asset_detail_screen.dart
+++ b/lib/ui/screens/asset_detail_screen.dart
@@ -463,6 +463,7 @@ class _AssetChartCardState extends ConsumerState<_AssetChartCard> {
                       baseCurrency: widget.currency,
                       locale: locale,
                       onZoom: _onZoom,
+                      zoomedY: _zoomMinY != null || _zoomMaxY != null,
                       child: UnifiedChart(
                         firstDate: widget.firstDate,
                         visible: widget.series,
@@ -476,6 +477,7 @@ class _AssetChartCardState extends ConsumerState<_AssetChartCard> {
                         zoomMinY: _zoomMinY,
                         zoomMaxY: _zoomMaxY,
                         isPrivate: isPrivate,
+                        zoomedX: _zoomMinX != null || _zoomMaxX != null,
                       ),
                     ),
                     if (hasZoom)

--- a/lib/ui/screens/dashboard/chart_card.dart
+++ b/lib/ui/screens/dashboard/chart_card.dart
@@ -218,6 +218,7 @@ class _ChartCard extends ConsumerWidget {
                       baseCurrency: allData.baseCurrency,
                       locale: locale,
                       onZoom: onZoom,
+                      zoomedY: zoomMinY != null || zoomMaxY != null,
                       child: UnifiedChart(
                         firstDate: allData.firstDate,
                         visible: drawnSeries,
@@ -231,6 +232,7 @@ class _ChartCard extends ConsumerWidget {
                         zoomMinY: zoomMinY,
                         zoomMaxY: zoomMaxY,
                         isPrivate: isPrivate,
+                        zoomedX: zoomMinX != null || zoomMaxX != null,
                       ),
                     );
                   })

--- a/lib/ui/screens/dashboard/unified_chart.dart
+++ b/lib/ui/screens/dashboard/unified_chart.dart
@@ -104,6 +104,10 @@ class DragZoomWrapper extends StatefulWidget {
   final DateTime firstDate;
   final String baseCurrency;
   final String locale;
+  /// True when the parent has explicitly zoomed Y (rectangle zoom set
+  /// non-null `zoomMinY`/`zoomMaxY`). Used to skip Y panning when Y is
+  /// just auto-fit — otherwise Shift+drag would jolt the auto-fit window.
+  final bool zoomedY;
   final void Function(double? minX, double? maxX, double? minY, double? maxY) onZoom;
 
   const DragZoomWrapper({super.key,
@@ -117,6 +121,7 @@ class DragZoomWrapper extends StatefulWidget {
     required this.baseCurrency,
     required this.locale,
     required this.onZoom,
+    this.zoomedY = false,
   });
 
   @override
@@ -145,8 +150,7 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
     return widget.yMin + fraction * (widget.yMax - widget.yMin);
   }
 
-  bool get _isZoomedX => (widget.xMax - widget.xMin) < widget.totalDays - 1e-6;
-  bool get _isZoomedY => (widget.yMax - widget.yMin) > 0;
+  bool get _isZoomedY => widget.zoomedY;
 
   void _resetTransientState() {
     _dragStart = null;
@@ -174,9 +178,10 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
     }
 
     double? newMinY, newMaxY;
-    if (yRange > 0 && chartHeight > 0) {
+    if (widget.zoomedY && yRange > 0 && chartHeight > 0) {
       // Y is inverted: dragging the mouse down should shift the visible
-      // window DOWN as well, so we add dy.
+      // window DOWN as well, so we add dy. Only pan Y when the user has
+      // explicitly zoomed Y; otherwise the auto-fit Y window must stay put.
       final dyUnits = e.delta.dy * yRange / chartHeight;
       newMinY = widget.yMin + dyUnits;
       newMaxY = widget.yMax + dyUnits;
@@ -186,6 +191,12 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
 
   void _handleWheelZoom(PointerScrollEvent sig, double chartWidth, double chartHeight) {
     if (chartWidth <= 0) return;
+    // Plain wheel must scroll the parent page; only zoom when the user
+    // explicitly opts in with Cmd (macOS) or Ctrl (Win/Linux) — same
+    // convention as Google Maps / Mapbox / Excel.
+    final cmdOrCtrl = HardwareKeyboard.instance.isControlPressed
+        || HardwareKeyboard.instance.isMetaPressed;
+    if (!cmdOrCtrl) return;
     final shift = HardwareKeyboard.instance.isShiftPressed;
     final factor = exp(-sig.scrollDelta.dy * 0.0015);
 
@@ -232,9 +243,6 @@ class _DragZoomWrapperState extends State<DragZoomWrapper> {
 
   void _onScaleUpdate(ScaleUpdateDetails d, double chartWidth) {
     if (_scaleStartMinX == null || chartWidth <= 0) return;
-
-    final isPinch = d.pointerCount >= 2;
-    if (!isPinch && !_isZoomedX) return; // let parent vertical scroll keep this gesture
 
     final startRange = _scaleStartMaxX! - _scaleStartMinX!;
     var newRange = startRange / d.scale;
@@ -425,8 +433,12 @@ class UnifiedChart extends StatelessWidget {
   final double? zoomMinY;
   final double? zoomMaxY;
   final bool isPrivate;
+  /// True when the X axis is currently zoomed in. Disables fl_chart's built-in
+  /// tap/drag tooltip handling so our parent ScaleGestureRecognizer can claim
+  /// single-finger pan on touch devices.
+  final bool zoomedX;
 
-  const UnifiedChart({super.key, 
+  const UnifiedChart({super.key,
     required this.firstDate,
     required this.visible,
     required this.totalSpots,
@@ -439,6 +451,7 @@ class UnifiedChart extends StatelessWidget {
     this.zoomMinY,
     this.zoomMaxY,
     this.isPrivate = false,
+    this.zoomedX = false,
   });
 
   @override
@@ -595,6 +608,7 @@ class UnifiedChart extends StatelessWidget {
         borderData: FlBorderData(show: false),
         lineTouchData: LineTouchData(
           enabled: !isPrivate,
+          handleBuiltInTouches: !zoomedX,
           touchTooltipData: LineTouchTooltipData(
             fitInsideHorizontally: true,
             fitInsideVertically: true,


### PR DESCRIPTION
## Summary

Three UX regressions in v0.7.1's chart zoom/pan:

- **Desktop wheel hijacked page scroll.** Plain mouse wheel over a chart zoomed it instead of scrolling the dashboard. Now plain wheel propagates to the parent; **Cmd (macOS) or Ctrl** + wheel zooms X, **Cmd/Ctrl + Shift** + wheel zooms Y. Same convention as Google Maps / Mapbox / Excel.
- **Mobile single-finger pan didn't work.** fl_chart's built-in tooltip recognizer was winning the gesture arena for 1-finger drags. Disabled \`handleBuiltInTouches\` when the chart is zoomed in, so our \`ScaleGestureRecognizer\` reliably claims pan. Pinch keeps working in both states (fl_chart can't handle multitouch). Tap-tooltip still works when not zoomed.
- **Shift+drag also panned auto-fit Y on desktop**, producing visual jolts when Y had never been user-zoomed. New \`zoomedY\` flag from the parent gates Y-pan to the case where the rectangle actually zoomed Y.

## Test plan

- [x] \`dart analyze\` clean
- [x] \`flutter test\` — 581/581 passed
- [x] \`flutter test integration_test/all_tests.dart -d macos\` — 2/2 passed
- [x] \`flutter test integration_test/live_data_fetch_test.dart -d macos\` — 1/1 passed
- [ ] CI green on PR
- [ ] Manual: Cmd+wheel zooms, plain wheel scrolls page (macOS)
- [ ] Manual: Pinch + 1-finger pan works on Pixel 7a