### PR TITLE
site: black background for GitHub Pages site

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,52 @@
+<style>
+  body {
+    background-color: #000 !important;
+    color: #e6e6e6;
+  }
+  .markdown-body {
+    color: #e6e6e6;
+    background-color: transparent;
+  }
+  .markdown-body a { color: #58a6ff; }
+  .markdown-body a:visited { color: #8e96f0; }
+  .markdown-body h1,
+  .markdown-body h2,
+  .markdown-body h3,
+  .markdown-body h4,
+  .markdown-body h5,
+  .markdown-body h6 {
+    color: #f0f6fc;
+    border-bottom-color: #30363d;
+  }
+  .markdown-body hr { background-color: #30363d; }
+  .markdown-body blockquote {
+    color: #8b949e;
+    border-left-color: #30363d;
+  }
+  .markdown-body code,
+  .markdown-body tt {
+    background-color: #161b22;
+    color: #e6e6e6;
+  }
+  .markdown-body pre {
+    background-color: #161b22;
+    color: #e6e6e6;
+  }
+  .markdown-body table tr {
+    background-color: transparent;
+    border-top-color: #30363d;
+  }
+  .markdown-body table tr:nth-child(2n) {
+    background-color: #0d1117;
+  }
+  .markdown-body table th,
+  .markdown-body table td {
+    border-color: #30363d;
+  }
+  .markdown-body kbd {
+    background-color: #161b22;
+    color: #e6e6e6;
+    border-color: #30363d;
+    box-shadow: inset 0 -1px 0 #30363d;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Adds `_includes/head-custom.html` with CSS overrides so https://financecopilot.bazzani.net/ has a black background with adjusted text/link/code/table colors for readability.
- Uses the default theme's documented head-custom hook (no theme/config changes).

## Test plan
- [ ] After merge, GH Pages rebuild → visit https://financecopilot.bazzani.net/ and confirm black background and legible text/links/code blocks/tables.