### PR TITLE
Persist portable language on startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,11 +40,19 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initLogging();
   await initializeDateFormatting();
+  final portableLanguage = await AppSettings.loadLanguageForStartup();
   // Print key paths to stdout for easy access
   // ignore: avoid_print
   print('LOG: $logFilePath');
   _log.info('FinanceCopilot v$appVersionDisplay starting up');
-  runApp(const ProviderScope(child: FinanceCopilotApp()));
+  runApp(
+    ProviderScope(
+      overrides: [
+        portableLanguageProvider.overrideWith((ref) => portableLanguage),
+      ],
+      child: const FinanceCopilotApp(),
+    ),
+  );
 }
 
 class FinanceCopilotApp extends ConsumerWidget {
@@ -331,7 +339,9 @@ class _AppShellState extends ConsumerState<AppShell> {
           label: s.settingsSyncSignIn,
           onPressed: () async {
             final ok = await sync.signIn();
-            if (ok) _log.info('Drive sync: re-authenticated as ${sync.userEmail}');
+            if (ok) {
+              _log.info('Drive sync: re-authenticated as ${sync.userEmail}');
+            }
           },
         ),
       ));
@@ -1211,7 +1221,9 @@ class _AppShellState extends ConsumerState<AppShell> {
                       ),
                       onPressed: () async {
                         await ref.read(marketPriceServiceProvider).clearCache();
-                        if (ctx.mounted) showInfoSnack(ctx, s.settingsCacheCleared);
+                        if (ctx.mounted) {
+                          showInfoSnack(ctx, s.settingsCacheCleared);
+                        }
                       },
                       child: Text(s.settingsClearButton),
                     ),

--- a/lib/services/app_settings.dart
+++ b/lib/services/app_settings.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
@@ -8,8 +9,17 @@ import 'package:path_provider/path_provider.dart';
 /// (portable between platforms, accessible before DB is opened).
 class AppSettings {
   static Directory? _resolvedConfigDir;
+  @visibleForTesting
+  static Directory? testConfigDir;
+  @visibleForTesting
+  static void resetForTesting() {
+    _resolvedConfigDir = null;
+    _cache = null;
+    testConfigDir = null;
+  }
 
   static Future<Directory> _getConfigDir() async {
+    if (testConfigDir != null) return testConfigDir!;
     if (_resolvedConfigDir != null) return _resolvedConfigDir!;
     _resolvedConfigDir = await getApplicationSupportDirectory();
     return _resolvedConfigDir!;
@@ -64,5 +74,11 @@ class AppSettings {
   /// Set the UI language.
   static Future<void> setLanguage(String lang) async {
     await set('language', lang);
+  }
+
+  /// Load the persisted UI language for app startup.
+  static Future<String> loadLanguageForStartup() async {
+    final lang = await getLanguage();
+    return lang.startsWith('it') ? 'it' : 'en';
   }
 }

--- a/test/app_settings_test.dart
+++ b/test/app_settings_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:finance_copilot/services/app_settings.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    AppSettings.resetForTesting();
+    tempDir = await Directory.systemTemp.createTemp('app_settings_test_');
+    AppSettings.testConfigDir = tempDir;
+  });
+
+  tearDown(() async {
+    AppSettings.resetForTesting();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('loadLanguageForStartup returns the persisted language', () async {
+    expect(await AppSettings.loadLanguageForStartup(), 'en');
+
+    await AppSettings.setLanguage('it');
+
+    expect(await AppSettings.loadLanguageForStartup(), 'it');
+  });
+
+  test(
+    'loadLanguageForStartup falls back to English for malformed values',
+    () async {
+      await AppSettings.set('language', 'pt');
+
+      expect(await AppSettings.loadLanguageForStartup(), 'en');
+    },
+  );
+}


### PR DESCRIPTION
Fixes #81.\n\n## Summary\n- load the persisted interface language before runApp\n- seed portableLanguageProvider from AppSettings instead of hardcoding English on startup\n- add focused tests for startup persistence and malformed fallback\n\n## Verification\n- dart analyze lib/main.dart lib/services/app_settings.dart test/app_settings_test.dart\n- flutter test test/app_settings_test.dart