### PR TITLE
Remove misleading rebalance target buys card

### DIFF
--- a/lib/l10n/app_strings.dart
+++ b/lib/l10n/app_strings.dart
@@ -133,7 +133,6 @@ class AppStrings {
   String get rebalanceEstimatedTax      => _it ? 'Tasse stimate'           : 'Estimated tax';
   String get rebalanceCashAfterSales    => _it ? 'Liquidità dopo le vendite' : 'Cash after sells';
   String get rebalanceAvailableCash     => _it ? 'Liquidità disponibile'   : 'Available cash';
-  String get rebalanceTargetBuy         => _it ? 'Acquisti target'         : 'Target buys';
   String get rebalanceExecutedBuy       => _it ? 'Acquisti eseguiti'       : 'Executed buys';
   String get rebalanceCashRemaining     => _it ? 'Contante residuo'        : 'Cash remaining';
   String get rebalanceWholeUnitsOnly    => _it ? 'Solo unità intere'       : 'Whole units only';

--- a/lib/ui/screens/pillars/rebalance_preview_dialog.dart
+++ b/lib/ui/screens/pillars/rebalance_preview_dialog.dart
@@ -212,12 +212,6 @@ class _DraftView extends StatelessWidget {
                       color: Colors.blue,
                     ),
                     _SummaryMetric(
-                      label: s.rebalanceTargetBuy,
-                      value: '${amountFormat.format(draft.targetBuyBase)} ${draft.baseCurrency}',
-                      icon: Icons.shopping_cart_outlined,
-                      color: Colors.orange,
-                    ),
-                    _SummaryMetric(
                       label: s.rebalanceExecutedBuy,
                       value: '${amountFormat.format(draft.executedBuyBase)} ${draft.baseCurrency}',
                       icon: Icons.check_circle_outline,

--- a/test/ui/rebalance_preview_dialog_test.dart
+++ b/test/ui/rebalance_preview_dialog_test.dart
@@ -1,0 +1,84 @@
+import 'package:drift/native.dart';
+import 'package:finance_copilot/database/database.dart';
+import 'package:finance_copilot/services/asset_event_service.dart';
+import 'package:finance_copilot/services/portfolio_rebalance_service.dart';
+import 'package:finance_copilot/services/providers/providers.dart';
+import 'package:finance_copilot/ui/screens/pillars/rebalance_preview_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  testWidgets('rebalance preview omits target buys summary card', (tester) async {
+    final draft = PortfolioRebalanceDraft(
+      mode: PortfolioRebalanceMode.sellAndBuy,
+      scope: const PortfolioRebalanceScope.currentPillar('pillar-1'),
+      baseCurrency: 'EUR',
+      rows: const [],
+      unresolved: const [],
+      availableCashBase: 1000,
+      targetBuyBase: 980,
+      executedBuyBase: 950,
+      buyShortfallBase: 30,
+      leftoverCashBase: 50,
+      currentPortfolioValueBase: 5000,
+      projectedPortfolioValueBase: 5950,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appLocaleProvider.overrideWith((ref) => Stream.value('en')),
+          portfolioRebalanceServiceProvider.overrideWithValue(_FakePortfolioRebalanceService(db, draft)),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: RebalancePreviewDialog(pillarId: 'pillar-1'),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Cash after sells'), findsOneWidget);
+    expect(find.text('Executed buys'), findsOneWidget);
+    expect(find.text('Estimated tax'), findsOneWidget);
+    expect(find.text('Cash remaining'), findsOneWidget);
+    expect(find.text('Target buys'), findsNothing);
+  });
+}
+
+class _FakePortfolioRebalanceService extends PortfolioRebalanceService {
+  final PortfolioRebalanceDraft draft;
+
+  _FakePortfolioRebalanceService(super.db, this.draft);
+
+  @override
+  Stream<PortfolioRebalanceDraft> buildDraftStream({
+    required PortfolioRebalanceScope scope,
+    required PortfolioRebalanceMode mode,
+    double contributionAmount = 0,
+    DateTime? asOf,
+  }) {
+    return Stream.value(draft);
+  }
+
+  @override
+  Future<List<int>> applyDraft(
+    PortfolioRebalanceDraft draft,
+    AssetEventService eventService, {
+    DateTime? date,
+  }) async {
+    return const [];
+  }
+}


### PR DESCRIPTION
## Summary
- remove the misleading Target buys summary card from the rebalance preview dialog
- drop the unused localized string for that card
- add a focused widget test covering the remaining summary metrics in the preview

## Validation
- dart analyze lib/ui/screens/pillars/rebalance_preview_dialog.dart lib/l10n/app_strings.dart test/ui/rebalance_preview_dialog_test.dart
- flutter test test/ui/rebalance_preview_dialog_test.dart