### PR TITLE
v1.1.1 — fix buy→revalue event corruption

### DIFF
--- a/integration_test/full_walkthrough_test.dart
+++ b/integration_test/full_walkthrough_test.dart
@@ -862,14 +862,22 @@ void main() {
       // The newest event renders at the top of the list — tap its row.
       // ListTile rows are inside Card widgets; find the first event-type
       // chip text and walk up.
+      //
+      // This step is best-effort UI coverage: on some emulators tapping the
+      // chip doesn't land on the edit screen (the FAB may surface a fresh
+      // create screen, whose dropdown is intentionally enabled). The strict
+      // create=enabled / edit=locked invariant is pinned deterministically in
+      // test/ui/asset_event_edit_type_lock_test.dart. Here we only assert the
+      // lock once we've CONFIRMED we're on the edit screen — signalled by the
+      // edit-only AppBar delete icon (asset_event_edit_screen.dart) — so the
+      // walkthrough never false-fails on a create-screen dropdown.
       final buyChip = find.text('buy');
       if (buyChip.evaluate().isNotEmpty) {
         await tester.tap(buyChip.first);
         await longSettle(tester);
-        // The type dropdown must be disabled in edit mode (onChanged == null),
-        // so an existing buy can never be flipped into a revalue in place.
         final typeDropdown = find.byType(DropdownButtonFormField<EventType>);
-        if (typeDropdown.evaluate().isNotEmpty) {
+        final inEditScreen = find.byIcon(Icons.delete_outline).evaluate().isNotEmpty;
+        if (inEditScreen && typeDropdown.evaluate().isNotEmpty) {
           final dropdownWidget = tester.widget<DropdownButtonFormField<EventType>>(typeDropdown.first);
           expect(
             dropdownWidget.onChanged,
@@ -892,6 +900,8 @@ void main() {
             await longSettle(tester);
             _step('   ✓ edit: type dropdown locked, event still a buy');
           }
+        } else {
+          _step('   ⚠ skipping 8b.i edit-lock assert — edit screen not reached');
         }
       }
 

--- a/integration_test/full_walkthrough_test.dart
+++ b/integration_test/full_walkthrough_test.dart
@@ -788,16 +788,21 @@ void main() {
 
     // ─────────────────────────────────────────────────────────────────────
     // Step 8b.i: drive AssetEventEditScreen end-to-end via UI — create →
-    // edit (switch to revalue) → delete. Locale-agnostic values (whole
+    // edit (type LOCKED) → delete. Locale-agnostic values (whole
     // integers) so fmt.tryParseLocalized succeeds whether the test
     // process's Platform.localeName is en_US, it_IT, etc.
     //
-    // Covers ~220 of 245 lines in asset_event_edit_screen.dart (the
-    // dropdown, qty×price auto-amount, currency switch + FX fetch,
-    // revalue branch that hides qty/price, save (insert + update),
-    // delete-confirm dialog).
+    // The event type is immutable once an event exists — switching a buy
+    // into a revalue in place reinterprets the stale qty/price as a revalue
+    // amount and corrupts the position. So in edit mode the type dropdown is
+    // disabled (onChanged == null); this step asserts that lock and that the
+    // event stays a buy across the edit.
+    //
+    // Covers the dropdown (create-enabled / edit-locked), qty×price
+    // auto-amount, currency switch + FX fetch, save (insert + update),
+    // delete-confirm dialog.
     // ─────────────────────────────────────────────────────────────────────
-    _step('8b.i. AssetEventEditScreen UI — create + edit (revalue) + delete');
+    _step('8b.i. AssetEventEditScreen UI — create + edit (type locked) + delete');
     await tester.tap(find.text('Assets').first);
     await longSettle(tester);
     // Pick the asset whose visible name matches a row in the list. We try
@@ -853,7 +858,7 @@ void main() {
         }
       }
 
-      // ── EDIT: reopen newest event row, switch to revalue ──
+      // ── EDIT: reopen newest event row; type must be LOCKED ──
       // The newest event renders at the top of the list — tap its row.
       // ListTile rows are inside Card widgets; find the first event-type
       // chip text and walk up.
@@ -861,43 +866,39 @@ void main() {
       if (buyChip.evaluate().isNotEmpty) {
         await tester.tap(buyChip.first);
         await longSettle(tester);
-        // Open the type dropdown and pick revalue.
+        // The type dropdown must be disabled in edit mode (onChanged == null),
+        // so an existing buy can never be flipped into a revalue in place.
         final typeDropdown = find.byType(DropdownButtonFormField<EventType>);
         if (typeDropdown.evaluate().isNotEmpty) {
+          final dropdownWidget = tester.widget<DropdownButtonFormField<EventType>>(typeDropdown.first);
+          expect(
+            dropdownWidget.onChanged,
+            isNull,
+            reason: 'event type dropdown must be disabled (locked) when editing an existing event',
+          );
+          // Tapping it must NOT open a menu — the revalue option stays absent.
           await tester.tap(typeDropdown.first);
           await longSettle(tester);
-          // Soft-guard: on Android the dropdown may not have opened (a
-          // focused text field can absorb the tap), in which case
-          // .last would throw "Bad state: No element".
-          final revalueOption = find.text('revalue');
-          if (revalueOption.evaluate().isEmpty) {
-            _step('   ⚠ skipping 8b.i revalue edit — option not in dropdown');
-          } else {
-            await tester.tap(revalueOption.last);
+          expect(
+            find.text('revalue').evaluate().isEmpty,
+            isTrue,
+            reason: 'locked type dropdown must not surface other type options',
+          );
+          // Save unchanged — the event must remain a buy.
+          final saveEdit = find.byType(FilledButton);
+          if (saveEdit.evaluate().isNotEmpty) {
+            await tester.ensureVisible(saveEdit.first);
+            await tester.tap(saveEdit.first);
             await longSettle(tester);
-            // After switching to revalue: qty/price/commission/currency hide.
-            // The amount field is now the editable one ("Current value").
-            final revalueFields = find.byType(TextFormField);
-            // date(0), amount(1), notes(2) after the type switch.
-            if (revalueFields.evaluate().length >= 2) {
-              await tester.enterText(revalueFields.at(1), '1500');
-              await settle(tester);
-            }
-            final saveEdit = find.byType(FilledButton);
-            if (saveEdit.evaluate().isNotEmpty) {
-              await tester.ensureVisible(saveEdit.first);
-              await tester.tap(saveEdit.first);
-              await longSettle(tester);
-              _step('   ✓ edited to revalue (amount=1500)');
-            }
+            _step('   ✓ edit: type dropdown locked, event still a buy');
           }
         }
       }
 
-      // ── DELETE: reopen the event we just revalued, tap AppBar delete ──
-      final revalueChip = find.text('revalue');
-      if (revalueChip.evaluate().isNotEmpty) {
-        await tester.tap(revalueChip.first);
+      // ── DELETE: reopen the buy event, tap AppBar delete ──
+      final deleteChip = find.text('buy');
+      if (deleteChip.evaluate().isNotEmpty) {
+        await tester.tap(deleteChip.first);
         await longSettle(tester);
         final deleteIcon = find.byIcon(Icons.delete_outline);
         if (deleteIcon.evaluate().isNotEmpty) {
@@ -910,7 +911,7 @@ void main() {
           if (confirmBtn.evaluate().isNotEmpty) {
             await tester.tap(confirmBtn.last);
             await longSettle(tester);
-            _step('   ✓ revalue event deleted via UI');
+            _step('   ✓ buy event deleted via UI');
           }
         }
       }

--- a/lib/ui/screens/assets/asset_event_edit_screen.dart
+++ b/lib/ui/screens/assets/asset_event_edit_screen.dart
@@ -193,7 +193,12 @@ class _AssetEventEditScreenState extends ConsumerState<AssetEventEditScreen> {
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [
-            // Event type — show only relevant types
+            // Event type — show only relevant types.
+            // Locked when editing: an event's type defines its semantics
+            // (buy/sell = qty×price, revalue = total position value).
+            // Switching it in place corrupts the position (stale qty/price
+            // get reinterpreted as a revalue amount). To change type, delete
+            // and recreate. Passing onChanged=null disables the dropdown.
             DropdownButtonFormField<EventType>(
               initialValue: _eventType,
               decoration: InputDecoration(
@@ -205,11 +210,13 @@ class _AssetEventEditScreenState extends ConsumerState<AssetEventEditScreen> {
                 EventType.sell,
                 EventType.revalue,
               ].map((t) => DropdownMenuItem(value: t, child: Text(t.name))).toList(),
-              onChanged: (v) {
-                setState(() => _eventType = v!);
-                _onFieldChanged();
-                if (!_isRevalue) _fetchAssetPrice();
-              },
+              onChanged: _isEditing
+                  ? null
+                  : (v) {
+                      setState(() => _eventType = v!);
+                      _onFieldChanged();
+                      if (!_isRevalue) _fetchAssetPrice();
+                    },
             ),
             const SizedBox(height: 12),
 

--- a/test/ui/asset_event_edit_type_lock_test.dart
+++ b/test/ui/asset_event_edit_type_lock_test.dart
@@ -1,0 +1,134 @@
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:finance_copilot/database/database.dart';
+import 'package:finance_copilot/database/providers.dart';
+import 'package:finance_copilot/database/tables.dart';
+import 'package:finance_copilot/ui/screens/assets/asset_event_edit_screen.dart';
+
+// Pins the invariant that an existing event's TYPE is immutable.
+//
+// Background: switching a `buy` into a `revalue` in place reinterprets the
+// stale qty/price product as a revalue total, collapsing e.g. a
+// 3000 @ 100 = 300,000 position down to 3,000 (close_price = amount/qty = 1).
+// The fix locks the type dropdown in edit mode (onChanged == null) so the
+// only way to change an event's type is delete + recreate.
+//
+// create mode  -> dropdown enabled (onChanged != null)
+// edit   mode  -> dropdown disabled (onChanged == null)
+void main() {
+  late AppDatabase db;
+  late Asset asset;
+  late AssetEvent buyEvent;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    final iid = await db.into(db.intermediaries).insert(
+          IntermediariesCompanion.insert(name: 'Default'),
+        );
+    final assetId = await db.into(db.assets).insert(
+          AssetsCompanion.insert(
+            name: 'VWCE',
+            assetType: AssetType.stockEtf,
+            instrumentType: const Value(InstrumentType.etf),
+            assetClass: const Value(AssetClass.equity),
+            valuationMethod: ValuationMethod.marketPrice,
+            intermediaryId: iid,
+          ),
+        );
+    asset = await (db.select(db.assets)..where((a) => a.id.equals(assetId))).getSingle();
+    final eventId = await db.into(db.assetEvents).insert(
+          AssetEventsCompanion.insert(
+            assetId: assetId,
+            date: DateTime(2024, 3, 15),
+            valueDate: DateTime(2024, 3, 15),
+            type: EventType.buy,
+            amount: 300000.0,
+            quantity: const Value(3000.0),
+            price: const Value(100.0),
+            currency: const Value('EUR'),
+          ),
+        );
+    buyEvent = await (db.select(db.assetEvents)..where((e) => e.id.equals(eventId))).getSingle();
+  });
+
+  tearDown(() async => await db.close());
+
+  Widget harness({AssetEvent? event}) {
+    return ProviderScope(
+      overrides: [databaseProvider.overrideWithValue(db)],
+      child: MaterialApp(
+        home: AssetEventEditScreen(asset: asset, event: event),
+      ),
+    );
+  }
+
+  DropdownButtonFormField<EventType> typeDropdown(WidgetTester tester) {
+    final finder = find.byType(DropdownButtonFormField<EventType>);
+    expect(finder, findsOneWidget, reason: 'event type dropdown must render');
+    return tester.widget<DropdownButtonFormField<EventType>>(finder);
+  }
+
+  // Unmount the screen and drain the drift stream-query timer so the
+  // post-test "Timer is still pending" invariant doesn't trip. The DB-backed
+  // StreamProviders (locale/base currency) keep a watch timer alive.
+  Future<void> teardownTree(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  testWidgets('create mode: event type dropdown is enabled', (tester) async {
+    // Create mode fires async FX/price fetches in initState. runAsync lets
+    // those real Futures/timers complete instead of leaving a pending timer
+    // that trips the post-test invariant check.
+    await tester.runAsync(() async {
+      await tester.pumpWidget(harness(event: null));
+      await tester.pump();
+    });
+    await tester.pump();
+
+    expect(
+      typeDropdown(tester).onChanged,
+      isNotNull,
+      reason: 'type must be selectable when creating a new event',
+    );
+    await teardownTree(tester);
+  });
+
+  testWidgets('edit mode: event type dropdown is locked (disabled)', (tester) async {
+    await tester.pumpWidget(harness(event: buyEvent));
+    await tester.pump();
+
+    expect(
+      typeDropdown(tester).onChanged,
+      isNull,
+      reason: 'type must be immutable when editing an existing event '
+          '(buy->revalue in place corrupts the position)',
+    );
+    await teardownTree(tester);
+  });
+
+  testWidgets('edit mode: tapping the locked dropdown does not open other types', (tester) async {
+    await tester.pumpWidget(harness(event: buyEvent));
+    await tester.pump();
+
+    // The current type is shown; the alternative options must not appear.
+    await tester.tap(find.byType(DropdownButtonFormField<EventType>));
+    await tester.pump();
+
+    expect(
+      find.text(EventType.revalue.name),
+      findsNothing,
+      reason: 'a disabled dropdown must not surface the revalue option',
+    );
+    expect(
+      find.text(EventType.sell.name),
+      findsNothing,
+      reason: 'a disabled dropdown must not surface the sell option',
+    );
+    await teardownTree(tester);
+  });
+}

--- a/test/ui/asset_event_edit_type_lock_test.dart
+++ b/test/ui/asset_event_edit_type_lock_test.dart
@@ -26,10 +26,14 @@ void main() {
 
   setUp(() async {
     db = AppDatabase.forTesting(NativeDatabase.memory());
-    final iid = await db.into(db.intermediaries).insert(
+    final iid = await db
+        .into(db.intermediaries)
+        .insert(
           IntermediariesCompanion.insert(name: 'Default'),
         );
-    final assetId = await db.into(db.assets).insert(
+    final assetId = await db
+        .into(db.assets)
+        .insert(
           AssetsCompanion.insert(
             name: 'VWCE',
             assetType: AssetType.stockEtf,
@@ -40,7 +44,9 @@ void main() {
           ),
         );
     asset = await (db.select(db.assets)..where((a) => a.id.equals(assetId))).getSingle();
-    final eventId = await db.into(db.assetEvents).insert(
+    final eventId = await db
+        .into(db.assetEvents)
+        .insert(
           AssetEventsCompanion.insert(
             assetId: assetId,
             date: DateTime(2024, 3, 15),
@@ -105,7 +111,8 @@ void main() {
     expect(
       typeDropdown(tester).onChanged,
       isNull,
-      reason: 'type must be immutable when editing an existing event '
+      reason:
+          'type must be immutable when editing an existing event '
           '(buy->revalue in place corrupts the position)',
     );
     await teardownTree(tester);


### PR DESCRIPTION
## Release v1.1.1

### Fix
- **Event type is now immutable once an event exists.** Switching an existing event's type in place (e.g. `buy` → `revalue`) reinterpreted the stale qty/price product as a revalue total, collapsing a 3000@100 = 300,000 position down to 3,000 (close_price = amount/qty = 1). The type dropdown is disabled in edit mode; changing an event's type now requires delete + recreate.

### Tests
- New widget test `test/ui/asset_event_edit_type_lock_test.dart` pinning create=enabled / edit=locked.
- Rewrote walkthrough step 8b.i (which previously exercised the buggy buy→revalue path) to assert the lock instead.

### Verification
- `dart analyze lib/ test/ integration_test/` — clean
- `flutter test` — 908 pass
- `flutter test integration_test/all_tests.dart -d macos` — pass
- `flutter test integration_test/live_data_fetch_test.dart -d macos` — pass