### PR TITLE
Release v1.2.1 — daily change midnight fix

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -379,6 +379,10 @@ class _AppShellState extends ConsumerState<AppShell> {
     if (_isSyncing) return;
     _isSyncing = true;
     try {
+      // Re-evaluate "today" so a refresh triggered after a day boundary clears
+      // a stale daily-change figure immediately (the provider also rolls over
+      // on its own midnight timer; this makes the user's action instant).
+      ref.invalidate(currentDateProvider);
       // Update network status indicator
       final online = await ref.read(networkMonitorProvider).check();
       ref.read(networkOnlineProvider.notifier).state = online;

--- a/lib/services/providers/app_state_providers.dart
+++ b/lib/services/providers/app_state_providers.dart
@@ -19,10 +19,25 @@ final privacyModeProvider = StateProvider<bool>((ref) => false);
 final waybackDateProvider = StateProvider<DateTime?>((ref) => null);
 
 /// Current date for user-facing read/display logic.
+///
+/// Recomputes automatically just after the next local midnight (via a
+/// self-scheduled timer) so day-boundary-sensitive views — today's change,
+/// YTD, chart cutoffs — roll over without an app restart. Previously this
+/// captured [DateTime.now] once at first read and went stale across midnight,
+/// leaving "today's change" showing yesterday's movement until relaunch.
+/// When a wayback override is set the date is pinned and no timer is armed.
 final currentDateProvider = Provider<DateTime>((ref) {
   final override = ref.watch(waybackDateProvider);
-  return dateOnly(override ?? DateTime.now());
+  if (override != null) return dateOnly(override);
+  final now = ref.watch(nowProvider)();
+  final timer = Timer(durationUntilNextDay(now), ref.invalidateSelf);
+  ref.onDispose(timer.cancel);
+  return dateOnly(now);
 });
+
+/// Wall-clock source. Overridable in tests so the day-rollover behaviour can be
+/// exercised deterministically; production always uses [DateTime.now].
+final nowProvider = Provider<DateTime Function()>((ref) => DateTime.now);
 
 /// Labels (chart titles) that have already triggered the ATH celebration
 /// overlay during this app session. Used to prevent the dashboard rebuild

--- a/lib/services/providers/providers.dart
+++ b/lib/services/providers/providers.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:drift/drift.dart';

--- a/lib/utils/visualization_clock.dart
+++ b/lib/utils/visualization_clock.dart
@@ -1,5 +1,16 @@
 DateTime dateOnly(DateTime value) => DateTime(value.year, value.month, value.day);
 
+/// Duration from [now] until just after the next local midnight.
+///
+/// Used to schedule the "today" rollover so day-boundary-sensitive views
+/// (today's price change, YTD, chart cutoffs) refresh on their own instead of
+/// showing a stale figure until the app is restarted. The extra second
+/// guarantees the timer fires just *after* the boundary, never a hair before.
+Duration durationUntilNextDay(DateTime now) {
+  final nextMidnight = DateTime(now.year, now.month, now.day).add(const Duration(days: 1));
+  return nextMidnight.difference(now) + const Duration(seconds: 1);
+}
+
 DateTime lastCompletedMonthEnd(DateTime today) {
   final d = dateOnly(today);
   return DateTime(d.year, d.month, 0);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -347,7 +347,7 @@ packages:
     source: hosted
     version: "3.0.0"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,9 @@ dev_dependencies:
 
   flutter_lints: ^6.0.0
 
+  # Deterministic timer/clock control in tests
+  fake_async: ^1.3.3
+
   # Drift code generation
   drift_dev: ^2.31.0
   build_runner: ^2.15.0

--- a/test/current_date_rollover_test.dart
+++ b/test/current_date_rollover_test.dart
@@ -1,0 +1,102 @@
+// Regression: the dashboard's "today's change" got stuck showing yesterday's
+// movement when the app was left running past midnight.
+//
+// Pinned bug: currentDateProvider was a plain Provider that captured
+// DateTime.now() on its first read (app startup) and only recomputed when the
+// wayback override changed — never when the wall clock crossed midnight. So an
+// app open across a day boundary kept treating the previous day as "today":
+// the "Today" KPI (change since today-1) then reported the prior day's full
+// price movement (e.g. +3227) instead of ~0 just after midnight, and a manual
+// refresh (which only bumps priceRefreshCounter) never cleared it.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:finance_copilot/services/providers/providers.dart';
+
+void main() {
+  test('currentDateProvider rolls over to the new day at midnight without a restart', () {
+    fakeAsync((async) {
+      var fakeNow = DateTime(2026, 7, 1, 23, 30); // 30 min before midnight
+      final container = ProviderContainer(
+        overrides: [nowProvider.overrideWithValue(() => fakeNow)],
+      );
+
+      // Before midnight: today = Jul 1.
+      expect(container.read(currentDateProvider), DateTime(2026, 7, 1));
+
+      // Wall clock advances past midnight; the self-scheduled timer fires.
+      fakeNow = DateTime(2026, 7, 2, 0, 0, 30);
+      async.elapse(const Duration(minutes: 31));
+
+      // The provider recomputed itself: today is now Jul 2 (no restart needed).
+      expect(container.read(currentDateProvider), DateTime(2026, 7, 2));
+
+      container.dispose(); // cancels the pending rollover timer inside the zone
+    });
+  });
+
+  test('rollover keeps firing across multiple day boundaries', () {
+    fakeAsync((async) {
+      var fakeNow = DateTime(2026, 7, 1, 12, 0);
+      final container = ProviderContainer(
+        overrides: [nowProvider.overrideWithValue(() => fakeNow)],
+      );
+
+      expect(container.read(currentDateProvider), DateTime(2026, 7, 1));
+
+      fakeNow = DateTime(2026, 7, 2, 12, 0);
+      async.elapse(const Duration(days: 1));
+      expect(container.read(currentDateProvider), DateTime(2026, 7, 2));
+
+      fakeNow = DateTime(2026, 7, 3, 12, 0);
+      async.elapse(const Duration(days: 1));
+      expect(container.read(currentDateProvider), DateTime(2026, 7, 3));
+
+      container.dispose();
+    });
+  });
+
+  test('wayback override pins the date and ignores the wall clock', () {
+    fakeAsync((async) {
+      var fakeNow = DateTime(2026, 7, 1, 23, 30);
+      final container = ProviderContainer(
+        overrides: [nowProvider.overrideWithValue(() => fakeNow)],
+      );
+      container.read(waybackDateProvider.notifier).state = DateTime(2020, 1, 15);
+
+      expect(container.read(currentDateProvider), DateTime(2020, 1, 15));
+
+      fakeNow = DateTime(2026, 7, 3, 0, 0, 30);
+      async.elapse(const Duration(days: 2));
+
+      // Still pinned to the wayback date.
+      expect(container.read(currentDateProvider), DateTime(2020, 1, 15));
+
+      container.dispose();
+    });
+  });
+
+  test('clearing the wayback override returns to the live (rolling) date', () {
+    fakeAsync((async) {
+      var fakeNow = DateTime(2026, 7, 1, 12, 0);
+      final container = ProviderContainer(
+        overrides: [nowProvider.overrideWithValue(() => fakeNow)],
+      );
+
+      container.read(waybackDateProvider.notifier).state = DateTime(2020, 1, 15);
+      expect(container.read(currentDateProvider), DateTime(2020, 1, 15));
+
+      container.read(waybackDateProvider.notifier).state = null;
+      expect(container.read(currentDateProvider), DateTime(2026, 7, 1));
+
+      // ...and the live date still rolls over afterwards.
+      fakeNow = DateTime(2026, 7, 2, 12, 0);
+      async.elapse(const Duration(days: 1));
+      expect(container.read(currentDateProvider), DateTime(2026, 7, 2));
+
+      container.dispose();
+    });
+  });
+}

--- a/test/visualization_clock_test.dart
+++ b/test/visualization_clock_test.dart
@@ -36,4 +36,32 @@ void main() {
     expect(nextYearEnd(DateTime(2026, 1, 1)), DateTime(2026, 12, 31));
     expect(nextYearEnd(DateTime(2026, 12, 31)), DateTime(2026, 12, 31));
   });
+
+  test('durationUntilNextDay counts down to just after the next midnight', () {
+    // 00:43 -> 23h17m until midnight, +1s guard.
+    expect(
+      durationUntilNextDay(DateTime(2026, 7, 2, 0, 43)),
+      const Duration(hours: 23, minutes: 17, seconds: 1),
+    );
+    // Just before midnight.
+    expect(
+      durationUntilNextDay(DateTime(2026, 7, 2, 23, 59, 30)),
+      const Duration(seconds: 31),
+    );
+    // Exactly at midnight -> a full day (+1s) to the next one.
+    expect(
+      durationUntilNextDay(DateTime(2026, 7, 2, 0, 0, 0)),
+      const Duration(days: 1, seconds: 1),
+    );
+    // Always strictly positive and within a day (+ the 1s guard).
+    for (final now in [
+      DateTime(2026, 1, 1, 0, 0, 1),
+      DateTime(2026, 6, 15, 12, 34, 56),
+      DateTime(2024, 2, 29, 18, 0),
+    ]) {
+      final d = durationUntilNextDay(now);
+      expect(d.inMilliseconds, greaterThan(0));
+      expect(d, lessThanOrEqualTo(const Duration(days: 1, seconds: 1)));
+    }
+  });
 }


### PR DESCRIPTION
Patch release. Fixes the dashboard daily-change getting stuck across midnight (currentDateProvider now rolls over at the day boundary; manual refresh re-evaluates the date). Adds fakeAsync rollover tests. CI green on develop (ef400bd).