### PR TITLE
Release v1.3.0 — Virtual portfolios

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -82,7 +82,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 47;
+  int get schemaVersion => 48;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -746,6 +746,14 @@ class AppDatabase extends _$AppDatabase {
         // which these sources don't have). Mark them cancelled. Status-only —
         // balance_after is intentionally NOT touched (it is already correct).
         await _migrateCancelledFromFilteredConfigs();
+      }
+      if (from < 48) {
+        if (!await _hasColumn('pillars', 'kind')) {
+          await customStatement(
+            "ALTER TABLE pillars ADD COLUMN kind TEXT NOT NULL DEFAULT 'standard'",
+          );
+        }
+        _log.info('Migration 48: added pillars.kind (default standard)');
       }
     },
     beforeOpen: (details) async {

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -12726,6 +12726,15 @@ class $PillarsTable extends Pillars with TableInfo<$PillarsTable, Pillar> {
     type: DriftSqlType.string,
     requiredDuringInsert: true,
   );
+  @override
+  late final GeneratedColumnWithTypeConverter<PillarKind, String> kind = GeneratedColumn<String>(
+    'kind',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('standard'),
+  ).withConverter<PillarKind>($PillarsTable.$converterkind);
   static const VerificationMeta _targetValueMeta = const VerificationMeta(
     'targetValue',
   );
@@ -12807,6 +12816,7 @@ class $PillarsTable extends Pillars with TableInfo<$PillarsTable, Pillar> {
   List<GeneratedColumn> get $columns => [
     id,
     name,
+    kind,
     targetValue,
     targetCurrency,
     portfolioModelId,
@@ -12901,6 +12911,12 @@ class $PillarsTable extends Pillars with TableInfo<$PillarsTable, Pillar> {
         DriftSqlType.string,
         data['${effectivePrefix}name'],
       )!,
+      kind: $PillarsTable.$converterkind.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}kind'],
+        )!,
+      ),
       targetValue: attachedDatabase.typeMapping.read(
         DriftSqlType.double,
         data['${effectivePrefix}target_value'],
@@ -12932,11 +12948,16 @@ class $PillarsTable extends Pillars with TableInfo<$PillarsTable, Pillar> {
   $PillarsTable createAlias(String alias) {
     return $PillarsTable(attachedDatabase, alias);
   }
+
+  static JsonTypeConverter2<PillarKind, String, String> $converterkind = const EnumNameConverter<PillarKind>(PillarKind.values);
 }
 
 class Pillar extends DataClass implements Insertable<Pillar> {
   final String id;
   final String name;
+
+  /// standard: partition-based; virtual: overlapping (no Objective).
+  final PillarKind kind;
   final double? targetValue;
   final String targetCurrency;
   final String? portfolioModelId;
@@ -12946,6 +12967,7 @@ class Pillar extends DataClass implements Insertable<Pillar> {
   const Pillar({
     required this.id,
     required this.name,
+    required this.kind,
     this.targetValue,
     required this.targetCurrency,
     this.portfolioModelId,
@@ -12958,6 +12980,9 @@ class Pillar extends DataClass implements Insertable<Pillar> {
     final map = <String, Expression>{};
     map['id'] = Variable<String>(id);
     map['name'] = Variable<String>(name);
+    {
+      map['kind'] = Variable<String>($PillarsTable.$converterkind.toSql(kind));
+    }
     if (!nullToAbsent || targetValue != null) {
       map['target_value'] = Variable<double>(targetValue);
     }
@@ -12975,6 +13000,7 @@ class Pillar extends DataClass implements Insertable<Pillar> {
     return PillarsCompanion(
       id: Value(id),
       name: Value(name),
+      kind: Value(kind),
       targetValue: targetValue == null && nullToAbsent ? const Value.absent() : Value(targetValue),
       targetCurrency: Value(targetCurrency),
       portfolioModelId: portfolioModelId == null && nullToAbsent ? const Value.absent() : Value(portfolioModelId),
@@ -12992,6 +13018,9 @@ class Pillar extends DataClass implements Insertable<Pillar> {
     return Pillar(
       id: serializer.fromJson<String>(json['id']),
       name: serializer.fromJson<String>(json['name']),
+      kind: $PillarsTable.$converterkind.fromJson(
+        serializer.fromJson<String>(json['kind']),
+      ),
       targetValue: serializer.fromJson<double?>(json['targetValue']),
       targetCurrency: serializer.fromJson<String>(json['targetCurrency']),
       portfolioModelId: serializer.fromJson<String?>(json['portfolioModelId']),
@@ -13006,6 +13035,9 @@ class Pillar extends DataClass implements Insertable<Pillar> {
     return <String, dynamic>{
       'id': serializer.toJson<String>(id),
       'name': serializer.toJson<String>(name),
+      'kind': serializer.toJson<String>(
+        $PillarsTable.$converterkind.toJson(kind),
+      ),
       'targetValue': serializer.toJson<double?>(targetValue),
       'targetCurrency': serializer.toJson<String>(targetCurrency),
       'portfolioModelId': serializer.toJson<String?>(portfolioModelId),
@@ -13018,6 +13050,7 @@ class Pillar extends DataClass implements Insertable<Pillar> {
   Pillar copyWith({
     String? id,
     String? name,
+    PillarKind? kind,
     Value<double?> targetValue = const Value.absent(),
     String? targetCurrency,
     Value<String?> portfolioModelId = const Value.absent(),
@@ -13027,6 +13060,7 @@ class Pillar extends DataClass implements Insertable<Pillar> {
   }) => Pillar(
     id: id ?? this.id,
     name: name ?? this.name,
+    kind: kind ?? this.kind,
     targetValue: targetValue.present ? targetValue.value : this.targetValue,
     targetCurrency: targetCurrency ?? this.targetCurrency,
     portfolioModelId: portfolioModelId.present ? portfolioModelId.value : this.portfolioModelId,
@@ -13038,6 +13072,7 @@ class Pillar extends DataClass implements Insertable<Pillar> {
     return Pillar(
       id: data.id.present ? data.id.value : this.id,
       name: data.name.present ? data.name.value : this.name,
+      kind: data.kind.present ? data.kind.value : this.kind,
       targetValue: data.targetValue.present ? data.targetValue.value : this.targetValue,
       targetCurrency: data.targetCurrency.present ? data.targetCurrency.value : this.targetCurrency,
       portfolioModelId: data.portfolioModelId.present ? data.portfolioModelId.value : this.portfolioModelId,
@@ -13052,6 +13087,7 @@ class Pillar extends DataClass implements Insertable<Pillar> {
     return (StringBuffer('Pillar(')
           ..write('id: $id, ')
           ..write('name: $name, ')
+          ..write('kind: $kind, ')
           ..write('targetValue: $targetValue, ')
           ..write('targetCurrency: $targetCurrency, ')
           ..write('portfolioModelId: $portfolioModelId, ')
@@ -13066,6 +13102,7 @@ class Pillar extends DataClass implements Insertable<Pillar> {
   int get hashCode => Object.hash(
     id,
     name,
+    kind,
     targetValue,
     targetCurrency,
     portfolioModelId,
@@ -13079,6 +13116,7 @@ class Pillar extends DataClass implements Insertable<Pillar> {
       (other is Pillar &&
           other.id == this.id &&
           other.name == this.name &&
+          other.kind == this.kind &&
           other.targetValue == this.targetValue &&
           other.targetCurrency == this.targetCurrency &&
           other.portfolioModelId == this.portfolioModelId &&
@@ -13090,6 +13128,7 @@ class Pillar extends DataClass implements Insertable<Pillar> {
 class PillarsCompanion extends UpdateCompanion<Pillar> {
   final Value<String> id;
   final Value<String> name;
+  final Value<PillarKind> kind;
   final Value<double?> targetValue;
   final Value<String> targetCurrency;
   final Value<String?> portfolioModelId;
@@ -13100,6 +13139,7 @@ class PillarsCompanion extends UpdateCompanion<Pillar> {
   const PillarsCompanion({
     this.id = const Value.absent(),
     this.name = const Value.absent(),
+    this.kind = const Value.absent(),
     this.targetValue = const Value.absent(),
     this.targetCurrency = const Value.absent(),
     this.portfolioModelId = const Value.absent(),
@@ -13111,6 +13151,7 @@ class PillarsCompanion extends UpdateCompanion<Pillar> {
   PillarsCompanion.insert({
     required String id,
     required String name,
+    this.kind = const Value.absent(),
     this.targetValue = const Value.absent(),
     this.targetCurrency = const Value.absent(),
     this.portfolioModelId = const Value.absent(),
@@ -13123,6 +13164,7 @@ class PillarsCompanion extends UpdateCompanion<Pillar> {
   static Insertable<Pillar> custom({
     Expression<String>? id,
     Expression<String>? name,
+    Expression<String>? kind,
     Expression<double>? targetValue,
     Expression<String>? targetCurrency,
     Expression<String>? portfolioModelId,
@@ -13134,6 +13176,7 @@ class PillarsCompanion extends UpdateCompanion<Pillar> {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (name != null) 'name': name,
+      if (kind != null) 'kind': kind,
       if (targetValue != null) 'target_value': targetValue,
       if (targetCurrency != null) 'target_currency': targetCurrency,
       if (portfolioModelId != null) 'portfolio_model_id': portfolioModelId,
@@ -13147,6 +13190,7 @@ class PillarsCompanion extends UpdateCompanion<Pillar> {
   PillarsCompanion copyWith({
     Value<String>? id,
     Value<String>? name,
+    Value<PillarKind>? kind,
     Value<double?>? targetValue,
     Value<String>? targetCurrency,
     Value<String?>? portfolioModelId,
@@ -13158,6 +13202,7 @@ class PillarsCompanion extends UpdateCompanion<Pillar> {
     return PillarsCompanion(
       id: id ?? this.id,
       name: name ?? this.name,
+      kind: kind ?? this.kind,
       targetValue: targetValue ?? this.targetValue,
       targetCurrency: targetCurrency ?? this.targetCurrency,
       portfolioModelId: portfolioModelId ?? this.portfolioModelId,
@@ -13176,6 +13221,11 @@ class PillarsCompanion extends UpdateCompanion<Pillar> {
     }
     if (name.present) {
       map['name'] = Variable<String>(name.value);
+    }
+    if (kind.present) {
+      map['kind'] = Variable<String>(
+        $PillarsTable.$converterkind.toSql(kind.value),
+      );
     }
     if (targetValue.present) {
       map['target_value'] = Variable<double>(targetValue.value);
@@ -13206,6 +13256,7 @@ class PillarsCompanion extends UpdateCompanion<Pillar> {
     return (StringBuffer('PillarsCompanion(')
           ..write('id: $id, ')
           ..write('name: $name, ')
+          ..write('kind: $kind, ')
           ..write('targetValue: $targetValue, ')
           ..write('targetCurrency: $targetCurrency, ')
           ..write('portfolioModelId: $portfolioModelId, ')
@@ -23626,6 +23677,7 @@ typedef $$PillarsTableCreateCompanionBuilder =
     PillarsCompanion Function({
       required String id,
       required String name,
+      Value<PillarKind> kind,
       Value<double?> targetValue,
       Value<String> targetCurrency,
       Value<String?> portfolioModelId,
@@ -23638,6 +23690,7 @@ typedef $$PillarsTableUpdateCompanionBuilder =
     PillarsCompanion Function({
       Value<String> id,
       Value<String> name,
+      Value<PillarKind> kind,
       Value<double?> targetValue,
       Value<String> targetCurrency,
       Value<String?> portfolioModelId,
@@ -23705,6 +23758,11 @@ class $$PillarsTableFilterComposer extends Composer<_$AppDatabase, $PillarsTable
   ColumnFilters<String> get name => $composableBuilder(
     column: $table.name,
     builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<PillarKind, PillarKind, String> get kind => $composableBuilder(
+    column: $table.kind,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
   );
 
   ColumnFilters<double> get targetValue => $composableBuilder(
@@ -23797,6 +23855,11 @@ class $$PillarsTableOrderingComposer extends Composer<_$AppDatabase, $PillarsTab
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get kind => $composableBuilder(
+    column: $table.kind,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<double> get targetValue => $composableBuilder(
     column: $table.targetValue,
     builder: (column) => ColumnOrderings(column),
@@ -23856,6 +23919,8 @@ class $$PillarsTableAnnotationComposer extends Composer<_$AppDatabase, $PillarsT
   GeneratedColumn<String> get id => $composableBuilder(column: $table.id, builder: (column) => column);
 
   GeneratedColumn<String> get name => $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<PillarKind, String> get kind => $composableBuilder(column: $table.kind, builder: (column) => column);
 
   GeneratedColumn<double> get targetValue => $composableBuilder(
     column: $table.targetValue,
@@ -23947,6 +24012,7 @@ class $$PillarsTableTableManager
               ({
                 Value<String> id = const Value.absent(),
                 Value<String> name = const Value.absent(),
+                Value<PillarKind> kind = const Value.absent(),
                 Value<double?> targetValue = const Value.absent(),
                 Value<String> targetCurrency = const Value.absent(),
                 Value<String?> portfolioModelId = const Value.absent(),
@@ -23957,6 +24023,7 @@ class $$PillarsTableTableManager
               }) => PillarsCompanion(
                 id: id,
                 name: name,
+                kind: kind,
                 targetValue: targetValue,
                 targetCurrency: targetCurrency,
                 portfolioModelId: portfolioModelId,
@@ -23969,6 +24036,7 @@ class $$PillarsTableTableManager
               ({
                 required String id,
                 required String name,
+                Value<PillarKind> kind = const Value.absent(),
                 Value<double?> targetValue = const Value.absent(),
                 Value<String> targetCurrency = const Value.absent(),
                 Value<String?> portfolioModelId = const Value.absent(),
@@ -23979,6 +24047,7 @@ class $$PillarsTableTableManager
               }) => PillarsCompanion.insert(
                 id: id,
                 name: name,
+                kind: kind,
                 targetValue: targetValue,
                 targetCurrency: targetCurrency,
                 portfolioModelId: portfolioModelId,

--- a/lib/database/tables.dart
+++ b/lib/database/tables.dart
@@ -119,6 +119,12 @@ enum EventEntryKind { scheduled, manual, reimbursement }
 
 enum PortfolioModelVariant { full, mini, custom }
 
+/// Discriminates between a real partition-based pillar (standard) and an
+/// overlapping virtual portfolio (virtual). Virtual portfolios share the same
+/// table and service but are exempt from the SUM-of-assigned ≤ total-holding
+/// invariant that governs standard pillars.
+enum PillarKind { standard, virtual }
+
 // ──────────────────────────────────────────────
 // Tables
 // ──────────────────────────────────────────────
@@ -462,10 +468,17 @@ class PortfolioModelItems extends Table {
 
 /// Pillar = a named bucket of asset units with an optional objective
 /// (portfolio model + target value). One asset's units can be split
-/// across multiple pillars; the leftover is the implicit "Unassigned" pillar.
+/// across multiple standard pillars; the leftover is the implicit "Unassigned"
+/// pillar. Virtual portfolios (kind == virtual) are exempt from the
+/// partition invariant: the same units can overlap across any number of virtual
+/// portfolios and real pillars simultaneously, capped only at 100% of the
+/// actual holding per virtual portfolio.
 class Pillars extends Table {
   TextColumn get id => text()(); // UUIDv7
   TextColumn get name => text().withLength(min: 1, max: 200)();
+
+  /// standard: partition-based; virtual: overlapping (no Objective).
+  TextColumn get kind => textEnum<PillarKind>().withDefault(const Constant('standard'))();
   RealColumn get targetValue => real().nullable()();
   TextColumn get targetCurrency => text().withLength(min: 3, max: 3).withDefault(const Constant('EUR'))();
   TextColumn get portfolioModelId => text().nullable().references(PortfolioModels, #id, onDelete: KeyAction.setNull)();

--- a/lib/l10n/app_strings.dart
+++ b/lib/l10n/app_strings.dart
@@ -83,6 +83,17 @@ class AppStrings {
   String get pillarPickPillar => _it ? 'Scegli pilastro' : 'Pick pillar';
   String get pillarTabPillars => _it ? 'Pilastri' : 'Pillars';
   String get pillarTabPortfolioModels => _it ? 'Modelli' : 'Portfolio Models';
+  String get pillarTabVirtualPortfolios => _it ? 'Portafogli virtuali' : 'Virtual Portfolios';
+
+  // ── Virtual Portfolios ─────────────────────────────────
+  String get virtualPortfolioCreateTitle => _it ? 'Nuovo portafoglio virtuale' : 'New virtual portfolio';
+  String get virtualPortfolioEditTitle => _it ? 'Modifica portafoglio virtuale' : 'Edit virtual portfolio';
+  String get virtualPortfoliosEmptyTitle => _it ? 'Nessun portafoglio virtuale' : 'No virtual portfolios yet';
+  String get virtualPortfoliosEmptyCta => _it ? 'Crea il tuo primo portafoglio virtuale' : 'Create your first virtual portfolio';
+  String get virtualPortfolioDeleteConfirm => _it
+      ? 'Eliminare questo portafoglio virtuale? Le assegnazioni verranno rimosse.'
+      : 'Delete this virtual portfolio? Assignments will be removed.';
+  String get pillarValueAndPerformance => _it ? 'Valore e rendimento' : 'Value & Performance';
   String get portfolioModelsBuiltIn => _it ? 'Predefiniti' : 'Built-in';
   String get portfolioModelsCustom => _it ? 'Personalizzati' : 'Custom';
   String get portfolioModelsEmpty => _it ? 'Nessun modello' : 'No models yet';

--- a/lib/services/pillars/pillar_service.dart
+++ b/lib/services/pillars/pillar_service.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart';
 
 import 'package:finance_copilot/database/database.dart';
+import 'package:finance_copilot/database/tables.dart';
 import 'package:finance_copilot/utils/logger.dart';
 import 'package:finance_copilot/utils/uuid_v7.dart';
 
@@ -32,6 +33,7 @@ class PillarService {
     double? targetValue,
     String targetCurrency = 'EUR',
     String? portfolioModelId,
+    PillarKind kind = PillarKind.standard,
   }) async {
     final id = UuidV7.generate();
     final maxSort = await (_db.selectOnly(
@@ -43,13 +45,14 @@ class PillarService {
           PillarsCompanion.insert(
             id: id,
             name: name,
+            kind: Value(kind),
             targetValue: Value(targetValue),
             targetCurrency: Value(targetCurrency),
             portfolioModelId: Value(portfolioModelId),
             sortOrder: Value((maxSort ?? -1) + 1),
           ),
         );
-    _log.info('create pillar id=$id name=$name');
+    _log.info('create pillar id=$id name=$name kind=${kind.name}');
     return id;
   }
 
@@ -86,11 +89,19 @@ class PillarService {
 
   // ── Pillar-asset assignments ──
 
-  /// Total quantity an asset already has assigned to pillars (excluding `excludePillarId` if given).
-  Future<double> _sumAssigned(int assetId, {String? excludePillarId}) async {
+  /// Total quantity an asset already has assigned to **standard** pillars
+  /// (excluding `excludePillarId` if given).
+  ///
+  /// Virtual portfolios are deliberately excluded from this sum so that their
+  /// overlapping assignments do not reduce the capacity of standard pillars or
+  /// the implicit "Unassigned" bucket.
+  Future<double> _sumStandardAssigned(int assetId, {String? excludePillarId}) async {
+    // Join pillar_assets → pillars so we can filter on kind = 'standard'.
     final query = _db.selectOnly(_db.pillarAssets)
+      ..join([innerJoin(_db.pillars, _db.pillars.id.equalsExp(_db.pillarAssets.pillarId))])
       ..addColumns([_db.pillarAssets.quantity.sum()])
-      ..where(_db.pillarAssets.assetId.equals(assetId));
+      ..where(_db.pillarAssets.assetId.equals(assetId))
+      ..where(_db.pillars.kind.equalsValue(PillarKind.standard));
     if (excludePillarId != null) {
       query.where(_db.pillarAssets.pillarId.equals(excludePillarId).not());
     }
@@ -119,9 +130,11 @@ class PillarService {
 
   Future<double> totalQuantity(int assetId) => _totalQuantity(assetId);
 
+  /// Quantity not yet assigned to any **standard** pillar (the "Unassigned" bucket).
+  /// Virtual assignments are independent and never reduce this value.
   Future<double> unassignedQty(int assetId) async {
     final total = await _totalQuantity(assetId);
-    final assigned = await _sumAssigned(assetId);
+    final assigned = await _sumStandardAssigned(assetId);
     final remaining = total - assigned;
     return remaining < 0 ? 0 : remaining;
   }
@@ -131,24 +144,37 @@ class PillarService {
     return row?.quantity ?? 0.0;
   }
 
-  /// Assign `qty` units of `assetId` to `pillarId`. Pass qty=0 to remove.
-  /// Throws [PillarOverAssignedException] if it would violate the invariant
-  /// SUM(pillar quantities) <= total holding.
+  /// Maximum quantity that can be assigned to [pillarId] for [assetId].
+  ///
+  /// - **Standard** pillars: `total − sum assigned to other standard pillars`
+  ///   (partition model; each unit can only live in one standard pillar).
+  /// - **Virtual** portfolios: `total` (overlap model; a virtual portfolio can
+  ///   hold up to 100% of the real holding independently of all other pillars).
+  Future<double> availableToAssign(String pillarId, int assetId) async {
+    final pillar = await getById(pillarId);
+    final total = await _totalQuantity(assetId);
+    if (pillar == null || pillar.kind == PillarKind.virtual) return total;
+    final otherStandard = await _sumStandardAssigned(assetId, excludePillarId: pillarId);
+    final available = total - otherStandard;
+    return available < 0 ? 0 : available;
+  }
+
+  /// Assign `qty` units of [assetId] to [pillarId]. Pass qty=0 to remove.
+  ///
+  /// For standard pillars, throws [PillarOverAssignedException] if the
+  /// assignment would violate SUM(standard quantities) <= total holding.
+  /// For virtual portfolios, the cap is simply the total holding (100%).
   Future<void> assign({
     required String pillarId,
     required int assetId,
     required double qty,
   }) async {
-    if (qty < 0) {
-      throw ArgumentError('qty must be >= 0');
-    }
+    if (qty < 0) throw ArgumentError('qty must be >= 0');
     if (qty == 0) {
       await unassign(pillarId: pillarId, assetId: assetId);
       return;
     }
-    final total = await _totalQuantity(assetId);
-    final otherAssigned = await _sumAssigned(assetId, excludePillarId: pillarId);
-    final available = total - otherAssigned;
+    final available = await availableToAssign(pillarId, assetId);
     if (qty > available + 1e-9) {
       throw PillarOverAssignedException(assetId, qty, available);
     }
@@ -179,13 +205,9 @@ class PillarService {
   }) async {
     // Validate up front so partial writes never happen.
     for (final entry in qtyByAsset.entries) {
-      if (entry.value < 0) {
-        throw ArgumentError('qty must be >= 0 (asset ${entry.key})');
-      }
+      if (entry.value < 0) throw ArgumentError('qty must be >= 0 (asset ${entry.key})');
       if (entry.value == 0) continue;
-      final total = await _totalQuantity(entry.key);
-      final otherAssigned = await _sumAssigned(entry.key, excludePillarId: pillarId);
-      final available = total - otherAssigned;
+      final available = await availableToAssign(pillarId, entry.key);
       if (entry.value > available + 1e-9) {
         throw PillarOverAssignedException(entry.key, entry.value, available);
       }
@@ -209,12 +231,16 @@ class PillarService {
     });
   }
 
-  /// Sets the row to `total - other_pillars` so the invariant holds, in case a
-  /// sell dropped the holding below the previously-assigned quantity.
+  /// Sets the row to `availableToAssign` so the invariant holds after a sell
+  /// dropped the holding below the previously-assigned quantity.
+  ///
+  /// For standard pillars: clamps to `total − other standard assigned`.
+  /// For virtual portfolios: clamps to `total` (each virtual is independent).
   Future<void> clipToFit(String pillarId, int assetId) async {
-    final total = await _totalQuantity(assetId);
-    final otherAssigned = await _sumAssigned(assetId, excludePillarId: pillarId);
-    final fit = total - otherAssigned;
+    final fit = await availableToAssign(pillarId, assetId);
+    final current = await qtyFor(pillarId, assetId);
+    // Nothing to do if the current assignment already fits.
+    if (current <= fit + 1e-9) return;
     if (fit <= 0) {
       await unassign(pillarId: pillarId, assetId: assetId);
     } else {
@@ -257,29 +283,53 @@ class PillarService {
     return out;
   }
 
-  /// Returns the assets with rows that exceed their current total (after a sell).
-  /// Each entry is (pillarId, assetId, storedQty, totalQty).
+  /// Returns assignments that exceed the per-kind capacity after a sell.
+  ///
+  /// - Standard pillars: the per-asset SUM across all standard pillar rows is
+  ///   compared to the total holding.
+  /// - Virtual portfolios: each row is checked individually against the total
+  ///   (they are independent; no cross-row sum applies).
   Future<List<({String pillarId, int assetId, double stored, double total})>> detectOverAssigned() async {
     final rows = await _db.select(_db.pillarAssets).get();
+    if (rows.isEmpty) return const [];
+
+    // Collect all unique asset ids and fetch their totals once.
+    final assetIds = rows.map((r) => r.assetId).toSet();
+    final totalByAsset = <int, double>{};
+    for (final id in assetIds) {
+      totalByAsset[id] = await _totalQuantity(id);
+    }
+
+    // Fetch the kind for each pillar that appears in the rows (batch).
+    final pillarIds = rows.map((r) => r.pillarId).toSet().toList();
+    final pillarRows = await (_db.select(_db.pillars)..where((p) => p.id.isIn(pillarIds))).get();
+    final kindById = {for (final p in pillarRows) p.id: p.kind};
+
+    // Standard: sum across all standard rows per asset, flag if sum > total.
+    final standardSumByAsset = <int, double>{};
+    for (final r in rows) {
+      if (kindById[r.pillarId] == PillarKind.standard) {
+        standardSumByAsset[r.assetId] = (standardSumByAsset[r.assetId] ?? 0) + r.quantity;
+      }
+    }
+
     final out = <({String pillarId, int assetId, double stored, double total})>[];
-    final byAsset = <int, double>{};
-    final assignedPerAsset = <int, double>{};
+
     for (final r in rows) {
-      assignedPerAsset[r.assetId] = (assignedPerAsset[r.assetId] ?? 0) + r.quantity;
-    }
-    for (final assetId in assignedPerAsset.keys) {
-      byAsset[assetId] = await _totalQuantity(assetId);
-    }
-    for (final r in rows) {
-      final total = byAsset[r.assetId] ?? 0;
-      if (assignedPerAsset[r.assetId]! > total + 1e-9) {
-        // mark only the rows in this asset that contribute > 0
-        out.add((
-          pillarId: r.pillarId,
-          assetId: r.assetId,
-          stored: r.quantity,
-          total: total,
-        ));
+      final total = totalByAsset[r.assetId] ?? 0;
+      final kind = kindById[r.pillarId];
+      if (kind == PillarKind.virtual) {
+        // Virtual: each row is independent — flag if this row alone exceeds total.
+        if (r.quantity > total + 1e-9) {
+          out.add((pillarId: r.pillarId, assetId: r.assetId, stored: r.quantity, total: total));
+        }
+      } else {
+        // Standard: flag any row in a standard pillar whose asset's total
+        // standard-assigned sum exceeds the holding.
+        final sum = standardSumByAsset[r.assetId] ?? 0;
+        if (sum > total + 1e-9) {
+          out.add((pillarId: r.pillarId, assetId: r.assetId, stored: r.quantity, total: total));
+        }
       }
     }
     return out;

--- a/lib/services/portfolio/portfolio_rebalance_service.dart
+++ b/lib/services/portfolio/portfolio_rebalance_service.dart
@@ -966,7 +966,10 @@ class PortfolioRebalanceService {
         if (pillarId == null) return Future.value(const <Pillar>[]);
         return (_db.select(_db.pillars)..where((p) => p.id.equals(pillarId))).get();
       case PortfolioRebalanceScopeKind.allAssociatedPillars:
-        return (_db.select(_db.pillars)..where((p) => p.portfolioModelId.isNotNull())).get();
+        // Exclude virtual portfolios from the batch scope: they overlap real
+        // holdings and including them would double-count buy/sell trades.
+        // Virtual portfolios can still be rebalanced individually via currentPillar.
+        return (_db.select(_db.pillars)..where((p) => p.portfolioModelId.isNotNull() & p.kind.equalsValue(PillarKind.standard))).get();
     }
   }
 

--- a/lib/services/providers/stream_providers.dart
+++ b/lib/services/providers/stream_providers.dart
@@ -27,6 +27,26 @@ final pillarsProvider = StreamProvider<List<Pillar>>((ref) {
   return ref.watch(pillarServiceProvider).watchAll();
 });
 
+/// Only standard (partition-based) pillars.
+final standardPillarsProvider = StreamProvider<List<Pillar>>((ref) {
+  return ref
+      .watch(pillarServiceProvider)
+      .watchAll()
+      .map(
+        (list) => list.where((p) => p.kind == PillarKind.standard).toList(),
+      );
+});
+
+/// Only virtual portfolios (overlap-based, no Objective).
+final virtualPortfoliosProvider = StreamProvider<List<Pillar>>((ref) {
+  return ref
+      .watch(pillarServiceProvider)
+      .watchAll()
+      .map(
+        (list) => list.where((p) => p.kind == PillarKind.virtual).toList(),
+      );
+});
+
 final pillarAssetsProvider = StreamProvider<List<PillarAsset>>((ref) {
   return ref.watch(pillarServiceProvider).watchAllAssignments();
 });

--- a/lib/ui/screens/pillars/pillar_create_dialog.dart
+++ b/lib/ui/screens/pillars/pillar_create_dialog.dart
@@ -10,7 +10,13 @@ import '../../../utils/formatters.dart' as fmt;
 
 class PillarCreateDialog extends ConsumerStatefulWidget {
   final Pillar? existing;
-  const PillarCreateDialog({super.key, this.existing});
+
+  /// When creating a new pillar, specifies whether it is a standard partition
+  /// pillar or a virtual (overlapping) portfolio. Ignored in edit mode
+  /// (the kind of an existing pillar is never changed).
+  final PillarKind kind;
+
+  const PillarCreateDialog({super.key, this.existing, this.kind = PillarKind.standard});
 
   @override
   ConsumerState<PillarCreateDialog> createState() => _PillarCreateDialogState();
@@ -21,6 +27,10 @@ class _PillarCreateDialogState extends ConsumerState<PillarCreateDialog> {
   late final TextEditingController _target;
   late String _currency;
   String? _portfolioModelId;
+
+  /// The effective kind: use the existing pillar's kind in edit mode,
+  /// otherwise use the kind passed to the dialog.
+  PillarKind get _kind => widget.existing?.kind ?? widget.kind;
 
   @override
   void initState() {
@@ -53,8 +63,14 @@ class _PillarCreateDialogState extends ConsumerState<PillarCreateDialog> {
     final locale = ref.watch(appLocaleProvider).value ?? 'en';
     final modelsAsync = ref.watch(portfolioModelsProvider);
     final isEdit = widget.existing != null;
+    final isVirtual = _kind == PillarKind.virtual;
+
+    final title = isEdit
+        ? (isVirtual ? s.virtualPortfolioEditTitle : s.pillarEditTitle)
+        : (isVirtual ? s.virtualPortfolioCreateTitle : s.pillarCreateTitle);
+
     return AlertDialog(
-      title: Text(isEdit ? s.pillarEditTitle : s.pillarCreateTitle),
+      title: Text(title),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -65,36 +81,39 @@ class _PillarCreateDialogState extends ConsumerState<PillarCreateDialog> {
               autofocus: true,
             ),
             const SizedBox(height: 12),
-            Row(
-              children: [
-                Expanded(
-                  flex: 3,
-                  child: TextField(
-                    controller: _target,
-                    keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                    decoration: InputDecoration(labelText: s.pillarFieldTargetValue),
+            // Objective (target value + currency) is only shown for standard pillars.
+            if (!isVirtual) ...[
+              Row(
+                children: [
+                  Expanded(
+                    flex: 3,
+                    child: TextField(
+                      controller: _target,
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      decoration: InputDecoration(labelText: s.pillarFieldTargetValue),
+                    ),
                   ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  flex: 1,
-                  child: DropdownButtonFormField<String>(
-                    initialValue: _currency,
-                    decoration: InputDecoration(labelText: s.pillarFieldTargetCurrency),
-                    items: const [
-                      DropdownMenuItem(value: 'EUR', child: Text('EUR')),
-                      DropdownMenuItem(value: 'USD', child: Text('USD')),
-                      DropdownMenuItem(value: 'GBP', child: Text('GBP')),
-                      DropdownMenuItem(value: 'CHF', child: Text('CHF')),
-                    ],
-                    onChanged: (v) {
-                      if (v != null) setState(() => _currency = v);
-                    },
+                  const SizedBox(width: 8),
+                  Expanded(
+                    flex: 1,
+                    child: DropdownButtonFormField<String>(
+                      initialValue: _currency,
+                      decoration: InputDecoration(labelText: s.pillarFieldTargetCurrency),
+                      items: const [
+                        DropdownMenuItem(value: 'EUR', child: Text('EUR')),
+                        DropdownMenuItem(value: 'USD', child: Text('USD')),
+                        DropdownMenuItem(value: 'GBP', child: Text('GBP')),
+                        DropdownMenuItem(value: 'CHF', child: Text('CHF')),
+                      ],
+                      onChanged: (v) {
+                        if (v != null) setState(() => _currency = v);
+                      },
+                    ),
                   ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
+                ],
+              ),
+              const SizedBox(height: 12),
+            ],
             modelsAsync.when(
               loading: () => const LinearProgressIndicator(),
               error: (e, _) => Text(s.error(e)),
@@ -135,7 +154,9 @@ class _PillarCreateDialogState extends ConsumerState<PillarCreateDialog> {
     final name = _name.text.trim();
     if (name.isEmpty) return;
     final svc = ref.read(pillarServiceProvider);
-    final targetTxt = _target.text.trim();
+    final isVirtual = _kind == PillarKind.virtual;
+    // Virtual portfolios never have a target value.
+    final targetTxt = isVirtual ? '' : _target.text.trim();
     final target = targetTxt.isEmpty ? null : fmt.tryParseLocalized(targetTxt, locale: locale);
     if (widget.existing == null) {
       await svc.create(
@@ -143,6 +164,7 @@ class _PillarCreateDialogState extends ConsumerState<PillarCreateDialog> {
         targetValue: target,
         targetCurrency: _currency,
         portfolioModelId: _portfolioModelId,
+        kind: _kind,
       );
     } else {
       await svc.update(

--- a/lib/ui/screens/pillars/pillar_detail_cards.dart
+++ b/lib/ui/screens/pillars/pillar_detail_cards.dart
@@ -247,7 +247,12 @@ class _ObjectiveCard extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(s.pillarObjective, style: Theme.of(context).textTheme.titleMedium),
+            // Title: "Objective" for standard pillars; "Value & Performance"
+            // for virtual portfolios (which have no target).
+            Text(
+              pillar.kind == PillarKind.virtual ? s.pillarValueAndPerformance : s.pillarObjective,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
             const SizedBox(height: 8),
             PrivacyText(s.pillarValue('${fmt.amountFormat(locale).format(value)} $baseCurrency')),
             if (hasTarget) ...[

--- a/lib/ui/screens/pillars/pillar_detail_overview.dart
+++ b/lib/ui/screens/pillars/pillar_detail_overview.dart
@@ -33,12 +33,13 @@ class _OverviewViewState extends ConsumerState<_OverviewView> {
       final total = await svc.totalQuantity(a.id);
       if (total <= 0) continue;
       final current = await svc.qtyFor(widget.pillarId, a.id);
-      final unassigned = await svc.unassignedQty(a.id);
-      final otherAssigned = total - unassigned - current;
+      // availableToAssign is kind-aware: standard → total − other standard
+      // assigned; virtual → total (independent per-portfolio cap).
+      final available = await svc.availableToAssign(widget.pillarId, a.id);
       out[a.id] = _AssetRowState(
         assetId: a.id,
         total: total,
-        otherAssigned: otherAssigned < 0 ? 0 : otherAssigned,
+        available: available,
         current: current,
       );
     }

--- a/lib/ui/screens/pillars/pillar_detail_screen.dart
+++ b/lib/ui/screens/pillars/pillar_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import '../../../database/database.dart';
+import '../../../database/tables.dart';
 import '../../../l10n/app_strings.dart';
 import '../../../models/dashboard_chart.dart';
 import 'package:finance_copilot/services/pillars/pillar_performance.dart';
@@ -116,7 +117,9 @@ class _PillarDetailScreenState extends ConsumerState<PillarDetailScreen> with Si
                   context: context,
                   builder: (ctx) => AlertDialog(
                     title: Text(s.delete),
-                    content: Text(s.pillarDeleteConfirm),
+                    content: Text(
+                      p.kind == PillarKind.virtual ? s.virtualPortfolioDeleteConfirm : s.pillarDeleteConfirm,
+                    ),
                     actions: [
                       TextButton(onPressed: () => Navigator.pop(ctx, false), child: Text(s.cancel)),
                       FilledButton(onPressed: () => Navigator.pop(ctx, true), child: Text(s.delete)),
@@ -174,16 +177,20 @@ class _PillarAssetsOverviewTab extends ConsumerWidget {
 class _AssetRowState {
   final int assetId;
   final double total;
-  final double otherAssigned;
+
+  /// Maximum qty that can be assigned to this pillar for this asset.
+  /// Kind-aware: standard = total − other standard assignments;
+  /// virtual = total (each virtual portfolio is independent).
+  final double available;
   double current;
   _AssetRowState({
     required this.assetId,
     required this.total,
-    required this.otherAssigned,
+    required this.available,
     required this.current,
   });
-  double get maxAvailable => total - otherAssigned;
-  double get maxPercent => total <= 0 ? 0 : (maxAvailable / total * 100).clamp(0.0, 100.0);
+  double get maxAvailable => available;
+  double get maxPercent => total <= 0 ? 0 : (available / total * 100).clamp(0.0, 100.0);
   double get currentPercent => total <= 0 ? 0 : (current / total * 100).clamp(0.0, 100.0);
 }
 

--- a/lib/ui/screens/pillars/pillars_screen.dart
+++ b/lib/ui/screens/pillars/pillars_screen.dart
@@ -29,7 +29,7 @@ class _PillarsScreenState extends ConsumerState<PillarsScreen> with SingleTicker
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 2, vsync: this)
+    _tabController = TabController(length: 3, vsync: this)
       ..addListener(() {
         if (!_tabController.indexIsChanging) setState(() {});
       });
@@ -44,12 +44,8 @@ class _PillarsScreenState extends ConsumerState<PillarsScreen> with SingleTicker
   @override
   Widget build(BuildContext context) {
     final s = ref.watch(appStringsProvider);
-    final pillarsAsync = ref.watch(pillarsProvider);
-    final assignmentsAsync = ref.watch(pillarAssetsProvider);
-    final performanceAsync = ref.watch(pillarPerformanceSnapshotsProvider);
-    final unassignedFracs = ref.watch(unassignedFractionProvider).value ?? {};
-    final baseCurrency = ref.watch(baseCurrencyProvider).value ?? 'EUR';
-    final locale = ref.watch(appLocaleProvider).value ?? 'en';
+    final standardAsync = ref.watch(standardPillarsProvider);
+    final virtualAsync = ref.watch(virtualPortfoliosProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -60,9 +56,10 @@ class _PillarsScreenState extends ConsumerState<PillarsScreen> with SingleTicker
           local: _tabController.index == 0
               ? [
                   _RebalanceToolbarMenu(
-                    pillarsAsync: pillarsAsync,
+                    // Rebalance menu only shows standard pillars (virtual are per-portfolio only).
+                    pillarsAsync: standardAsync,
                     onSelected: (choice) async {
-                      final fallbackPillarId = pillarsAsync.value?.isNotEmpty == true ? pillarsAsync.value!.first.id : null;
+                      final fallbackPillarId = standardAsync.value?.isNotEmpty == true ? standardAsync.value!.first.id : null;
                       await showDialog(
                         context: context,
                         builder: (_) => RebalancePreviewDialog(
@@ -79,93 +76,43 @@ class _PillarsScreenState extends ConsumerState<PillarsScreen> with SingleTicker
           controller: _tabController,
           tabs: [
             Tab(text: s.pillarTabPillars),
+            Tab(text: s.pillarTabVirtualPortfolios),
             Tab(text: s.pillarTabPortfolioModels),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        tooltip: _tabController.index == 0 ? s.pillarCreateTitle : s.portfolioModelCreateTitle,
-        onPressed: () => _tabController.index == 0 ? _openCreateDialog(context, ref) : _openModelDialog(context),
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: switch (_tabController.index) {
+        0 => FloatingActionButton(
+          tooltip: s.pillarCreateTitle,
+          onPressed: () => _openCreateDialog(context, PillarKind.standard),
+          child: const Icon(Icons.add),
+        ),
+        1 => FloatingActionButton(
+          tooltip: s.virtualPortfolioCreateTitle,
+          onPressed: () => _openCreateDialog(context, PillarKind.virtual),
+          child: const Icon(Icons.add),
+        ),
+        _ => FloatingActionButton(
+          tooltip: s.portfolioModelCreateTitle,
+          onPressed: () => _openModelDialog(context),
+          child: const Icon(Icons.add),
+        ),
+      },
       body: TabBarView(
         controller: _tabController,
         children: [
-          pillarsAsync.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (e, _) => Center(child: Text('$e')),
-            data: (pillars) {
-              final assignments = assignmentsAsync.value ?? const [];
-              final performanceByPillar = performanceAsync.value ?? const <String, PillarPerformanceSnapshot>{};
-
-              double valueOfUnassigned() {
-                final marketValues = ref.watch(assetMarketValuesProvider).value ?? {};
-                double total = 0;
-                unassignedFracs.forEach((assetId, frac) {
-                  final mv = marketValues[assetId] ?? 0;
-                  total += mv * frac;
-                });
-                return total;
-              }
-
-              int assetCount(String id) => assignments.where((x) => x.pillarId == id).length;
-
-              if (pillars.isEmpty) {
-                return Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(32),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.view_quilt_outlined, size: 48, color: Theme.of(context).colorScheme.onSurfaceVariant),
-                        const SizedBox(height: 16),
-                        Text(s.pillarsEmptyTitle, textAlign: TextAlign.center),
-                        const SizedBox(height: 16),
-                        FilledButton.icon(
-                          icon: const Icon(Icons.add),
-                          label: Text(s.pillarsEmptyCta),
-                          onPressed: () => _openCreateDialog(context, ref),
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              }
-
-              final unassignedValue = valueOfUnassigned();
-
-              return ListView(
-                padding: const EdgeInsets.all(8),
-                children: [
-                  for (final p in pillars)
-                    _PillarCard(
-                      pillar: p,
-                      performance: performanceByPillar[p.id],
-                      assetCount: assetCount(p.id),
-                      baseCurrency: baseCurrency,
-                      locale: locale,
-                    ),
-                  if (unassignedValue > 0)
-                    _UnassignedCard(
-                      value: unassignedValue,
-                      assetCount: unassignedFracs.values.where((f) => f > 0).length,
-                      baseCurrency: baseCurrency,
-                      locale: locale,
-                    ),
-                ],
-              );
-            },
-          ),
+          _PillarList(pillarsAsync: standardAsync, kind: PillarKind.standard),
+          _PillarList(pillarsAsync: virtualAsync, kind: PillarKind.virtual),
           const _PortfolioModelsTab(),
         ],
       ),
     );
   }
 
-  Future<void> _openCreateDialog(BuildContext context, WidgetRef ref) async {
+  Future<void> _openCreateDialog(BuildContext context, PillarKind kind) async {
     await showDialog(
       context: context,
-      builder: (_) => const PillarCreateDialog(),
+      builder: (_) => PillarCreateDialog(kind: kind),
     );
   }
 
@@ -173,6 +120,101 @@ class _PillarsScreenState extends ConsumerState<PillarsScreen> with SingleTicker
     await showDialog(
       context: context,
       builder: (_) => const PortfolioModelDialog(),
+    );
+  }
+}
+
+/// Shared list body for both the Pillars tab and the Virtual Portfolios tab.
+/// [kind] controls the empty-state copy and whether the Unassigned card is shown.
+class _PillarList extends ConsumerWidget {
+  final AsyncValue<List<Pillar>> pillarsAsync;
+  final PillarKind kind;
+
+  const _PillarList({required this.pillarsAsync, required this.kind});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final s = ref.watch(appStringsProvider);
+    final assignmentsAsync = ref.watch(pillarAssetsProvider);
+    final performanceAsync = ref.watch(pillarPerformanceSnapshotsProvider);
+    final unassignedFracs = ref.watch(unassignedFractionProvider).value ?? {};
+    final baseCurrency = ref.watch(baseCurrencyProvider).value ?? 'EUR';
+    final locale = ref.watch(appLocaleProvider).value ?? 'en';
+
+    return pillarsAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('$e')),
+      data: (pillars) {
+        final assignments = assignmentsAsync.value ?? const [];
+        final performanceByPillar = performanceAsync.value ?? const <String, PillarPerformanceSnapshot>{};
+
+        int assetCount(String id) => assignments.where((x) => x.pillarId == id).length;
+
+        if (pillars.isEmpty) {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    kind == PillarKind.virtual ? Icons.folder_special_outlined : Icons.view_quilt_outlined,
+                    size: 48,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    kind == PillarKind.virtual ? s.virtualPortfoliosEmptyTitle : s.pillarsEmptyTitle,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  FilledButton.icon(
+                    icon: const Icon(Icons.add),
+                    label: Text(kind == PillarKind.virtual ? s.virtualPortfoliosEmptyCta : s.pillarsEmptyCta),
+                    onPressed: () => showDialog(
+                      context: context,
+                      builder: (_) => PillarCreateDialog(kind: kind),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        // Unassigned card only makes sense for standard pillars (the partition model).
+        final showUnassigned = kind == PillarKind.standard;
+        double unassignedValue = 0;
+        int unassignedCount = 0;
+        if (showUnassigned) {
+          final marketValues = ref.watch(assetMarketValuesProvider).value ?? {};
+          unassignedFracs.forEach((assetId, frac) {
+            unassignedValue += (marketValues[assetId] ?? 0) * frac;
+          });
+          unassignedCount = unassignedFracs.values.where((f) => f > 0).length;
+        }
+
+        return ListView(
+          padding: const EdgeInsets.all(8),
+          children: [
+            for (final p in pillars)
+              _PillarCard(
+                pillar: p,
+                performance: performanceByPillar[p.id],
+                assetCount: assetCount(p.id),
+                baseCurrency: baseCurrency,
+                locale: locale,
+              ),
+            if (showUnassigned && unassignedValue > 0)
+              _UnassignedCard(
+                value: unassignedValue,
+                assetCount: unassignedCount,
+                baseCurrency: baseCurrency,
+                locale: locale,
+              ),
+          ],
+        );
+      },
     );
   }
 }

--- a/test/offline_first_test.dart
+++ b/test/offline_first_test.dart
@@ -206,7 +206,7 @@ void main() {
   });
 
   group('DB merge column intersection', () {
-    test('schema version is 47 after the current migration chain', () async {
+    test('schema version is 48 after the current migration chain', () async {
       // v36 added Pillars + PillarAssets. v37 dropped
       // pillars.reference_portfolio. v38 dropped pillars.emoji. v39 dropped
       // assets.yahoo_ticker + registered_events. v40 renamed legacy
@@ -220,9 +220,10 @@ void main() {
       // v45 made import_configs.account_id nullable (rebuild).
       // v46 dropped ValuationMethod.balance (assets converted to marketPrice).
       // v47 marked cancelled transactions from filtered import configs.
+      // v48 added pillars.kind (standard vs virtual portfolios).
       final rows = await db.customSelect('PRAGMA user_version').get();
       final version = rows.first.read<int>('user_version');
-      expect(version, 47);
+      expect(version, 48);
     });
 
     test('dashboard_charts table is gone', () async {

--- a/test/pillar_service_test.dart
+++ b/test/pillar_service_test.dart
@@ -123,4 +123,129 @@ void main() {
     expect(const PillarScope.pillar('a') == const PillarScope.pillar('a'), true);
     expect(const PillarScope.pillar('a') == const PillarScope.pillar('b'), false);
   });
+
+  // ── Virtual Portfolio tests ──────────────────────────────────────────
+
+  test('virtual portfolio can overlap a fully-assigned standard pillar', () async {
+    // asset has 10 units, fully assigned to a standard pillar
+    final assetId = await newAssetWithUnits(10);
+    final standard = await pillars.create(name: 'Standard', kind: PillarKind.standard);
+    await pillars.assign(pillarId: standard, assetId: assetId, qty: 10);
+    expect(await pillars.unassignedQty(assetId), 0);
+
+    // virtual portfolio can still assign all 10 (overlap — independent of standard)
+    final virtual = await pillars.create(name: 'Virtual', kind: PillarKind.virtual);
+    await pillars.assign(pillarId: virtual, assetId: assetId, qty: 10);
+    expect(await pillars.qtyFor(virtual, assetId), 10);
+  });
+
+  test('virtual assignment does not reduce capacity of standard pillars', () async {
+    final assetId = await newAssetWithUnits(10);
+    final virtual = await pillars.create(name: 'Virtual', kind: PillarKind.virtual);
+    await pillars.assign(pillarId: virtual, assetId: assetId, qty: 10);
+
+    // Standard pillar should still see full 10 available
+    final standard = await pillars.create(name: 'Standard', kind: PillarKind.standard);
+    await pillars.assign(pillarId: standard, assetId: assetId, qty: 10);
+    expect(await pillars.qtyFor(standard, assetId), 10);
+    expect(await pillars.unassignedQty(assetId), 0);
+  });
+
+  test('two virtual portfolios can both hold 100% of the same asset', () async {
+    final assetId = await newAssetWithUnits(10);
+    final v1 = await pillars.create(name: 'V1', kind: PillarKind.virtual);
+    final v2 = await pillars.create(name: 'V2', kind: PillarKind.virtual);
+    await pillars.assign(pillarId: v1, assetId: assetId, qty: 10);
+    await pillars.assign(pillarId: v2, assetId: assetId, qty: 10);
+    expect(await pillars.qtyFor(v1, assetId), 10);
+    expect(await pillars.qtyFor(v2, assetId), 10);
+  });
+
+  test('virtual assignment capped at total — over-100% throws', () async {
+    final assetId = await newAssetWithUnits(10);
+    final virtual = await pillars.create(name: 'Virtual', kind: PillarKind.virtual);
+    expect(
+      () => pillars.assign(pillarId: virtual, assetId: assetId, qty: 11),
+      throwsA(isA<PillarOverAssignedException>()),
+    );
+  });
+
+  test('fractionsForPillar = 1.0 when virtual holds all units', () async {
+    final assetId = await newAssetWithUnits(10);
+    final virtual = await pillars.create(name: 'Virtual', kind: PillarKind.virtual);
+    await pillars.assign(pillarId: virtual, assetId: assetId, qty: 10);
+    final fracs = await pillars.fractionsForPillar(virtual);
+    expect(fracs[assetId], closeTo(1.0, 1e-9));
+  });
+
+  test('availableToAssign: standard respects other standard, virtual returns total', () async {
+    final assetId = await newAssetWithUnits(10);
+    final s1 = await pillars.create(name: 'S1', kind: PillarKind.standard);
+    await pillars.assign(pillarId: s1, assetId: assetId, qty: 4);
+
+    // A second standard pillar sees only 6 available
+    final s2 = await pillars.create(name: 'S2', kind: PillarKind.standard);
+    expect(await pillars.availableToAssign(s2, assetId), closeTo(6, 1e-9));
+
+    // A virtual portfolio always sees the full 10
+    final v = await pillars.create(name: 'V', kind: PillarKind.virtual);
+    expect(await pillars.availableToAssign(v, assetId), closeTo(10, 1e-9));
+  });
+
+  test('clipToFit for virtual clips to total after a sell', () async {
+    final assetId = await newAssetWithUnits(10);
+    final virtual = await pillars.create(name: 'Virtual', kind: PillarKind.virtual);
+    await pillars.assign(pillarId: virtual, assetId: assetId, qty: 10);
+    // sell 3 → total now 7
+    await events.create(
+      assetId: assetId,
+      date: DateTime.now(),
+      type: EventType.sell,
+      quantity: 3,
+      amount: 30,
+      currency: 'EUR',
+    );
+    await pillars.clipToFit(virtual, assetId);
+    expect(await pillars.qtyFor(virtual, assetId), closeTo(7, 1e-9));
+  });
+
+  test('detectOverAssigned flags virtual rows that exceed total', () async {
+    final assetId = await newAssetWithUnits(10);
+    final virtual = await pillars.create(name: 'Virtual', kind: PillarKind.virtual);
+    await pillars.assign(pillarId: virtual, assetId: assetId, qty: 10);
+    // sell 3 → virtual row (10) now exceeds total (7)
+    await events.create(
+      assetId: assetId,
+      date: DateTime.now(),
+      type: EventType.sell,
+      quantity: 3,
+      amount: 30,
+      currency: 'EUR',
+    );
+    final overs = await pillars.detectOverAssigned();
+    expect(overs.where((o) => o.assetId == assetId && o.pillarId == virtual).isNotEmpty, true);
+  });
+
+  test('detectOverAssigned: virtual over-sell does NOT flag unrelated standard pillar', () async {
+    final assetId = await newAssetWithUnits(10);
+    final standard = await pillars.create(name: 'Standard', kind: PillarKind.standard);
+    await pillars.assign(pillarId: standard, assetId: assetId, qty: 6);
+    final virtual = await pillars.create(name: 'Virtual', kind: PillarKind.virtual);
+    await pillars.assign(pillarId: virtual, assetId: assetId, qty: 10);
+    // sell 5 → total = 5; standard (6) > 5, virtual (10) > 5 — both flagged
+    // but the standard flag is due to standard sum, not virtual
+    await events.create(
+      assetId: assetId,
+      date: DateTime.now(),
+      type: EventType.sell,
+      quantity: 5,
+      amount: 50,
+      currency: 'EUR',
+    );
+    final overs = await pillars.detectOverAssigned();
+    final virtualOver = overs.where((o) => o.pillarId == virtual).isNotEmpty;
+    final standardOver = overs.where((o) => o.pillarId == standard).isNotEmpty;
+    expect(virtualOver, true);
+    expect(standardOver, true);
+  });
 }

--- a/test/portfolio_model_service_test.dart
+++ b/test/portfolio_model_service_test.dart
@@ -202,7 +202,7 @@ void main() {
 
     final migrated = AppDatabase.forTesting(NativeDatabase(File(path)));
     final version = (await migrated.customSelect('PRAGMA user_version').get()).first.read<int>('user_version');
-    expect(version, 47);
+    expect(version, 48);
     final modelTables = await migrated
         .customSelect(
           "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('portfolio_models', 'portfolio_model_items')",

--- a/test/ui/pillar_performance_widgets_test.dart
+++ b/test/ui/pillar_performance_widgets_test.dart
@@ -103,6 +103,8 @@ Widget _testApp({
       appLocaleProvider.overrideWith((ref) => Stream.value('en')),
       baseCurrencyProvider.overrideWithValue(const AsyncData('EUR')),
       pillarsProvider.overrideWithValue(AsyncData([pillar])),
+      standardPillarsProvider.overrideWithValue(AsyncData([pillar])),
+      virtualPortfoliosProvider.overrideWithValue(const AsyncData([])),
       activeAssetsProvider.overrideWithValue(const AsyncData([])),
       assetsProvider.overrideWithValue(const AsyncData([])),
       pillarAssetsProvider.overrideWithValue(const AsyncData([])),


### PR DESCRIPTION
## v1.3.0 — Virtual portfolios

Introduces **virtual portfolios**: overlapping, objective-free asset buckets that live alongside the existing partition-based pillars.

### Highlights
- New `PillarKind` (`standard` | `virtual`). A virtual portfolio can hold up to 100% of an asset's holding independently of every other pillar, and never reduces the capacity of standard pillars or the implicit "Unassigned" bucket.
- `PillarService`: `_sumStandardAssigned` + `availableToAssign` gate `assign`/`clipToFit`/`detectOverAssigned` per kind (standard partition vs. virtual overlap).
- New `standardPillarsProvider` / `virtualPortfoliosProvider`.
- Pillars screen gains a third **Virtual Portfolios** tab with a shared list body.
- Localized strings (en/it).

### Schema
- Adds `pillars.kind`; migration bumps schema **v47 → v48** (default `standard`, fully backward-compatible).

### Tests
- New `PillarService` cases for virtual overlap (a virtual portfolio can overlap a fully-assigned standard pillar; two virtuals can each hold 100%).
- Updated schema-version assertion to 48; overrode the new pillar providers in the pillar widget test.

All gates green locally: `dart analyze` clean, 1060 unit tests, macOS integration suite, and live-data-fetch test all pass. develop CI green.